### PR TITLE
dndmc datapack 2.0

### DIFF
--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/aarakocra.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/aarakocra.json
@@ -1,0 +1,25 @@
+{
+	"attack_style":"slash",
+	"attack_element":"wind",
+	
+	"defense_stlye":{
+		"slash":-15,
+		"stab":-15,
+		"explosion":25,
+		"magic":25,
+		"projectile":-30
+	},
+	
+	"defense_element":{
+		"water":30,
+		"wind":80,
+		"earth":50,
+		"fire":-20,
+		"ice":-20,
+		"thunder":-60,
+		"light":50,
+		"darkness":-50
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/aboleth.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/aboleth.json
@@ -1,0 +1,22 @@
+{
+	"attack_style":"slash",
+	"attack_element":"water",
+	
+	"defense_stlye":{
+        "slash":15,
+        "stab":15,
+		"explosion":5,
+		"magic":-20,
+		"projectile":-5
+	},
+	
+	"defense_element":{
+		"fire":50,
+		"ice":-50,
+		"thunder":-50,
+		"darkness":50,
+		"light":-50
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/allip.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/allip.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"magic",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":50,
+		"stab":50,
+		"explosion":50,
+		"magic":10,
+		"projectile":70
+	},
+	
+	"defense_element":{
+		"water":-30,
+		"wind":-75,
+		"earth":-75,
+		"fire":50,
+		"ice":100,
+		"thunder":60,
+		"light":-60,
+		"darkness":100,
+		"bio":100
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/ancient_green_dragon.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/ancient_green_dragon.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"bio",
+	
+	"defense_stlye":{
+		"slash":75,
+		"stab":75,
+		"explosion":75,
+		"magic":85,
+		"projectile":20
+	},
+	
+	"defense_element":{
+		"water":25,
+		"wind":55,
+		"earth":55,
+		"fire":-70,
+		"ice":-30,
+		"thunder":-45,
+		"light":-45,
+		"darkness":50,
+		"bio":100
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/ancient_red_dragon.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/ancient_red_dragon.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"fire",
+	
+	"defense_stlye":{
+		"slash":95,
+		"stab":95,
+		"explosion":95,
+		"magic":85,
+		"projectile":95
+	},
+	
+	"defense_element":{
+		"water":-85,
+		"wind":55,
+		"earth":35,
+		"fire":100,
+		"ice":-60,
+		"thunder":45,
+		"light":-60,
+		"darkness":50,
+		"bio":30
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/ancient_white_dragon.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/ancient_white_dragon.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"ice",
+	
+	"defense_stlye":{
+		"slash":80,
+		"stab":70,
+		"explosion":80,
+		"magic":15,
+		"projectile":0
+	},
+	
+	"defense_element":{
+		"water":25,
+		"wind":50,
+		"earth":25,
+		"fire":-50,
+		"ice":100,
+		"thunder":-25,
+		"light":-50,
+		"darkness":100,
+		"bio":-50
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/androsphinx.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/androsphinx.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"magic",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":100,
+		"stab":100,
+		"explosion":100,
+		"magic":70,
+		"projectile":100
+	},
+	
+	"defense_element":{
+		"water":-50,
+		"wind":85,
+		"earth":35,
+		"fire":60,
+		"ice":-85,
+		"thunder":30,
+		"light":60,
+		"darkness":50,
+		"bio":-85
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/animated_armor.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/animated_armor.json
@@ -1,0 +1,25 @@
+{
+	"attack_style":"basic",
+	"attack_element":"wind",
+	
+	"defense_stlye":{
+		"slash":25,
+		"stab":25,
+		"explosion":15,
+		"magic":-25,
+		"projectile":23
+	},
+	
+	"defense_element":{
+		"water":1,
+		"wind":80,
+		"earth":-40,
+		"fire":1,
+		"ice":1,
+		"thunder":1,
+		"light":-40,
+		"darkness":-30
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/ankheg.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/ankheg.json
@@ -1,0 +1,19 @@
+{
+	"attack_style":"slash",
+	"attack_element":"bio",
+	
+	"defense_stlye":{
+        "slash":25,
+        "stab":15,
+		"explosion":5,
+		"magic":-20,
+		"projectile":10
+	},
+	
+	"defense_element":{
+		"fire":-35,
+		"earth":50
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/ant.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/ant.json
@@ -1,0 +1,22 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":15,
+		"stab":15,
+		"explosion":5,
+		"magic":-1,
+		"projectile":5
+	},
+	
+	"defense_element":{
+		"water":-10,
+		"wind":30,
+		"earth":50,
+		"fire":-50,
+		"ice":-50
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/arochs.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/arochs.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":35,
+		"stab":25,
+		"explosion":35,
+		"magic":1,
+		"projectile":25
+	},
+	
+	"defense_element":{
+		"water":15,
+		"wind":15,
+		"earth":25,
+		"fire":30,
+		"ice":70,
+		"thunder":20,
+		"light":10,
+		"darkness":10,
+		"bio":-30
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/axe_beak.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/axe_beak.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"stab",
+	"attack_element":"wind",
+	
+	"defense_stlye":{
+		"slash":10,
+		"stab":10,
+		"explosion":10,
+		"magic":-25,
+		"projectile":10
+	},
+	
+	"defense_element":{
+		"water":25,
+		"wind":45,
+		"earth":-35,
+		"fire":-30,
+		"ice":-20,
+		"thunder":20,
+		"light":10,
+		"darkness":10,
+		"bio":10
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/azer.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/azer.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"fire",
+	
+	"defense_stlye":{
+		"slash":5,
+		"stab":5,
+		"explosion":50,
+		"magic":-15,
+		"projectile":-50
+	},
+	
+	"defense_element":{
+		"water":-50,
+		"wind":40,
+		"earth":10,
+		"fire":100,
+		"ice":-25,
+		"thunder":15,
+		"light":50,
+		"darkness":10,
+		"bio": 110
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/balhannoth.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/balhannoth.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"water",
+	
+	"defense_stlye":{
+		"slash":40,
+		"stab":40,
+		"explosion":40,
+		"magic":-5,
+		"projectile":-10
+	},
+	
+	"defense_element":{
+		"water":55,
+		"wind":-15,
+		"earth":-15,
+		"fire":20,
+		"ice":-10,
+		"thunder":-30,
+		"light":-30,
+		"darkness":55,
+		"bio":50
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/banderhobb.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/banderhobb.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"stab",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":50,
+		"stab":50,
+		"explosion":50,
+		"magic":25,
+		"projectile":10
+	},
+	
+	"defense_element":{
+		"water":35,
+		"wind":-35,
+		"earth":-35,
+		"fire":10,
+		"ice":-10,
+		"thunder":10,
+		"light":-30,
+		"darkness":40,
+		"bio":30
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/banshee.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/banshee.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"magic",
+	"attack_element":"darkness",
+	
+	"defense_stlye":{
+		"slash":50,
+		"stab":50,
+		"explosion":50,
+		"magic":-50,
+		"projectile":50
+	},
+	
+	"defense_element":{
+		"water":25,
+		"wind":-5,
+		"earth":25,
+		"fire":50,
+		"ice":100,
+		"thunder":50,
+		"light":-75,
+		"darkness":100,
+		"bio":150
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/barghest.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/barghest.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"fire",
+	
+	"defense_stlye":{
+		"slash":10,
+		"stab":1,
+		"explosion":1,
+		"magic":-5s,
+		"projectile":1
+	},
+	
+	"defense_element":{
+		"water":-35,
+		"wind":-1,
+		"earth":-1,
+		"fire":75,
+		"ice":-20,
+		"thunder":50,
+		"light":-35,
+		"darkness":75,
+		"bio":1
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/basilisk.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/basilisk.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"stab",
+	"attack_element":"bio",
+	
+	"defense_stlye":{
+		"slash":1,
+		"stab":1,
+		"explosion":5,
+		"magic":-25,
+		"projectile":1
+	},
+	
+	"defense_element":{
+		"water":55,
+		"wind":35,
+		"earth":25,
+		"fire":-10,
+		"ice":-10,
+		"thunder":-10,
+		"light":10,
+		"darkness":10,
+		"bio":100
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/behir.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/behir.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"stab",
+	"attack_element":"lightning",
+	
+	"defense_stlye":{
+		"slash":40,
+		"stab":40,
+		"explosion":40,
+		"magic":5,
+		"projectile":30
+	},
+	
+	"defense_element":{
+		"water":35,
+		"wind":15,
+		"earth":-35,
+		"fire":30,
+		"ice":30,
+		"thunder":70,
+		"light":-40,
+		"darkness":50,
+		"bio":30
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/beholder.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/beholder.json
@@ -1,0 +1,18 @@
+{
+	"attack_style":"stab",
+	"attack_element":"darkness",
+	
+	"defense_stlye":{
+		"slash":20,
+		"stab":20,
+		"magic":20,
+		"projectile":20
+	},
+	
+	"defense_element":{
+		"darkness":30,
+		"light":-30
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/berbalang.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/berbalang.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"stab",
+	"attack_element":"earth",
+	
+	"defense_stlye":{
+		"slash":-5,
+		"stab":-5,
+		"explosion":-5,
+		"magic":40,
+		"projectile":30
+	},
+	
+	"defense_element":{
+		"water":-5,
+		"wind":-25,
+		"earth":25,
+		"fire":15,
+		"ice":5,
+		"thunder":15,
+		"light":-25,
+		"darkness":50,
+		"bio":10
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/black_pudding.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/black_pudding.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"bio",
+	
+	"defense_stlye":{
+		"slash":100,
+		"stab":1,
+		"explosion":1,
+		"magic":-25,
+		"projectile":1
+	},
+	
+	"defense_element":{
+		"water":25,
+		"wind":25,
+		"earth":25,
+		"fire":-50,
+		"ice":100,
+		"thunder":100,
+		"light":10,
+		"darkness":10,
+		"bio":100
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/blink_dog.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/blink_dog.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"stab",
+	"attack_element":"light",
+	
+	"defense_stlye":{
+		"slash":15,
+		"stab":15,
+		"explosion":5,
+		"magic":15,
+		"projectile":5
+	},
+	
+	"defense_element":{
+		"water":15,
+		"wind":15,
+		"earth":15,
+		"fire":10,
+		"ice":10,
+		"thunder":10,
+		"light":70,
+		"darkness":-50,
+		"bio":10
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/boar.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/boar.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"stab",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":-15,
+		"stab":-25,
+		"explosion":-15,
+		"magic":1,
+		"projectile":-25
+	},
+	
+	"defense_element":{
+		"water":15,
+		"wind":15,
+		"earth":25,
+		"fire":-15,
+		"ice":10,
+		"thunder":-15,
+		"light":-10,
+		"darkness":-30,
+		"bio":-10
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/bodak.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/bodak.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"darkness",
+	
+	"defense_stlye":{
+		"slash":50,
+		"stab":50,
+		"explosion":50,
+		"magic":25,
+		"projectile":1
+	},
+	
+	"defense_element":{
+		"water":-35,
+		"wind":-25,
+		"earth":15,
+		"fire":50,
+		"ice":50,
+		"thunder":100,
+		"light":-80,
+		"darkness":100,
+		"bio":100
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/boggle.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/boggle.json
@@ -1,0 +1,23 @@
+{
+	"attack_style":"magic",
+	"attack_element":"light",
+	
+	"defense_stlye":{
+		"slash":10,
+		"stab":10,
+		"explosion":5,
+		"magic":5,
+		"projectile":5
+	},
+	
+	"defense_element":{
+		"light":100,
+		"wind":10,
+		"earth":10,
+		"fire":50,
+		"ice":-20,
+		"darkness":-50
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/bone_claw.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/bone_claw.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"ice",
+	
+	"defense_stlye":{
+		"slash":70,
+		"stab":50,
+		"explosion":70,
+		"magic":25,
+		"projectile":30
+	},
+	
+	"defense_element":{
+		"water":25,
+		"wind":25,
+		"earth":-15,
+		"fire":-50,
+		"ice":75,
+		"thunder":-10,
+		"light":-30,
+		"darkness":60,
+		"bio":60
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/brown_bear.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/brown_bear.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":15,
+		"stab":15,
+		"explosion":15,
+		"magic":1,
+		"projectile":10
+	},
+	
+	"defense_element":{
+		"water":25,
+		"wind":25,
+		"earth":25,
+		"fire":5,
+		"ice":5,
+		"thunder":-20,
+		"light":-10,
+		"darkness":-10,
+		"bio":20
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/brush_gnome.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/brush_gnome.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":1,
+		"stab":1,
+		"explosion":1,
+		"magic":15,
+		"projectile":1
+	},
+	
+	"defense_element":{
+		"water":-15,
+		"wind":-15,
+		"earth":-15,
+		"fire":20,
+		"ice":20,
+		"thunder":20,
+		"light":10,
+		"darkness":10,
+		"bio":10
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/bugbear.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/bugbear.json
@@ -1,0 +1,25 @@
+{
+	"attack_style":"basic",
+	"attack_element":"earth",
+	
+	"defense_stlye":{
+		"slash":15,
+		"stab":15,
+		"explosion":45,
+		"magic":-15,
+		"projectile":5
+	},
+	
+	"defense_element":{
+		"water":1,
+		"wind":10,
+		"earth":50,
+		"fire":20,
+		"ice":20,
+		"thunder":-20,
+		"light":20,
+		"darkness":-40
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/bulette.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/bulette.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"stab",
+	"attack_element":"earth",
+	
+	"defense_stlye":{
+		"slash":25,
+		"stab":15,
+		"explosion":25,
+		"magic":-25,
+		"projectile":15
+	},
+	
+	"defense_element":{
+		"water":-20,
+		"wind":-45,
+		"earth":75,
+		"fire":10,
+		"ice":10,
+		"thunder":10,
+		"light":-10,
+		"darkness":10,
+		"bio":-30
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/bullywug.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/bullywug.json
@@ -1,0 +1,22 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":5,
+		"stab":5,
+		"explosion":1,
+		"magic":-1,
+		"projectile":3
+	},
+	
+	"defense_element":{
+		"water":40,
+		"wind":40,
+		"earth":-40,
+		"fire":20,
+		"ice":-20
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/bunyip.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/bunyip.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"bio",
+	
+	"defense_stlye":{
+		"slash":30,
+		"stab":30,
+		"explosion":30,
+		"magic":-20,
+		"projectile":10
+	},
+	
+	"defense_element":{
+		"water":20,
+		"wind":5,
+		"earth":5,
+		"fire":10,
+		"ice":0,
+		"thunder":-20,
+		"light":-30,
+		"darkness":60,
+		"bio":30
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/carrion_crawler.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/carrion_crawler.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"bio",
+	
+	"defense_stlye":{
+		"slash":25,
+		"stab":25,
+		"explosion":25,
+		"magic":-35,
+		"projectile":15
+	},
+	
+	"defense_element":{
+		"water":35,
+		"wind":-25,
+		"earth":-35,
+		"fire":-20,
+		"ice":-10,
+		"thunder":-20,
+		"light":-25,
+		"darkness":25,
+		"bio":60
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/catoblepas.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/catoblepas.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"bio",
+	
+	"defense_stlye":{
+		"slash":55,
+		"stab":55,
+		"explosion":55,
+		"magic":-5,
+		"projectile":10
+	},
+	
+	"defense_element":{
+		"water":35,
+		"wind":-35,
+		"earth":-35,
+		"fire":10,
+		"ice":-10,
+		"thunder":-20,
+		"light":10,
+		"darkness":50,
+		"bio":35
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/cave_fisher.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/cave_fisher.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":35,
+		"stab":25,
+		"explosion":40,
+		"magic":-5,
+		"projectile":10
+	},
+	
+	"defense_element":{
+		"water":5,
+		"wind":-25,
+		"earth":45,
+		"fire":5,
+		"ice":5,
+		"thunder":5,
+		"light":10,
+		"darkness":10,
+		"bio":15
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/cave_troll.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/cave_troll.json
@@ -1,0 +1,20 @@
+{
+	"attack_style":"basic",
+	"attack_element":"earth",
+	
+	"defense_stlye":{
+		"slash":65,
+		"stab":65,
+		"explosion":30,
+		"magic":-40,
+		"projectile":65
+	},
+	
+	"defense_element":{
+		"darkness":-30,
+		"fire":-75,
+		"light":-30
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/centaur.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/centaur.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"stab",
+	"attack_element":"earth",
+	
+	"defense_stlye":{
+		"slash":10,
+		"stab":10,
+		"explosion":10,
+		"magic":-15,
+		"projectile":5
+	},
+	
+	"defense_element":{
+		"water":5,
+		"wind":-25,
+		"earth":55,
+		"fire":-10,
+		"ice":10,
+		"thunder":-10,
+		"light":-10,
+		"darkness":-10,
+		"bio":50
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/chimera.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/chimera.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"stab",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":45,
+		"stab":45,
+		"explosion":45,
+		"magic":-15,
+		"projectile":5
+	},
+	
+	"defense_element":{
+		"water":-35,
+		"wind":25,
+		"earth":-25,
+		"fire":50,
+		"ice":-30,
+		"thunder":50,
+		"light":-40,
+		"darkness":70,
+		"bio":50
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/chitine.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/chitine.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"stab",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":10,
+		"stab":10,
+		"explosion":10,
+		"magic":-5,
+		"projectile":20
+	},
+	
+	"defense_element":{
+		"water":25,
+		"wind":15,
+		"earth":-25,
+		"fire":20,
+		"ice":-20,
+		"thunder":-20,
+		"light":-30,
+		"darkness":60,
+		"bio":10
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/choldrith.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/choldrith.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"stab",
+	"attack_element":"bio",
+	
+	"defense_stlye":{
+		"slash":10,
+		"stab":10,
+		"explosion":10,
+		"magic":25,
+		"projectile":30
+	},
+	
+	"defense_element":{
+		"water":25,
+		"wind":-15,
+		"earth":15,
+		"fire":-30,
+		"ice":-10,
+		"thunder":10,
+		"light":-30,
+		"darkness":60,
+		"bio":60
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/chull.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/chull.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"magic",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":25,
+		"stab":25,
+		"explosion":25,
+		"magic":60,
+		"projectile":20
+	},
+	
+	"defense_element":{
+		"water":30,
+		"wind":-45,
+		"earth":-25,
+		"fire":20,
+		"ice":-10,
+		"thunder":-40,
+		"light":-35,
+		"darkness":70,
+		"bio":20
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/clay_golem.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/clay_golem.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"earth",
+	
+	"defense_stlye":{
+		"slash":40,
+		"stab":40,
+		"explosion":40,
+		"magic":-15,
+		"projectile":-5
+	},
+	
+	"defense_element":{
+		"water":55,
+		"wind":35,
+		"earth":65,
+		"fire":-30,
+		"ice":-20,
+		"thunder":10,
+		"light":30,
+		"darkness":30,
+		"bio":110
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/cloaker.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/cloaker.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"wind",
+	
+	"defense_stlye":{
+		"slash":10,
+		"stab":10,
+		"explosion":10,
+		"magic":25,
+		"projectile":25
+	},
+	
+	"defense_element":{
+		"water":15,
+		"wind":35,
+		"earth":-15,
+		"fire":20,
+		"ice":20,
+		"thunder":-30,
+		"light":-50,
+		"darkness":50,
+		"bio":20
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/cloud_giant.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/cloud_giant.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"wind",
+	
+	"defense_stlye":{
+		"slash":25,
+		"stab":25,
+		"explosion":35,
+		"magic":35,
+		"projectile":15
+	},
+	
+	"defense_element":{
+		"water":5,
+		"wind":90,
+		"earth":30,
+		"fire":30,
+		"ice":30,
+		"thunder":20,
+		"light":40,
+		"darkness":-60,
+		"bio":-60
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/cockatrice.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/cockatrice.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":-15,
+		"stab":-25,
+		"explosion":-15,
+		"magic":15,
+		"projectile":-25
+	},
+	
+	"defense_element":{
+		"water":-15,
+		"wind":65,
+		"earth":-15,
+		"fire":-20,
+		"ice":-10,
+		"thunder":30,
+		"light":10,
+		"darkness":10,
+		"bio":-20
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/crawling_claw.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/crawling_claw.json
@@ -1,0 +1,19 @@
+{
+	"attack_style":"basic",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":-5,
+		"stab":-5,
+		"explosion":-15,
+		"magic":10,
+		"projectile":-10
+	},
+	
+	"defense_element":{
+		"fire":-15,
+		"bio":100
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/cyclops.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/cyclops.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"earth",
+	
+	"defense_stlye":{
+		"slash":50,
+		"stab":5,
+		"explosion":65,
+		"magic":1,
+		"projectile":5
+	},
+	
+	"defense_element":{
+		"water":-25,
+		"wind":-35,
+		"earth":80,
+		"fire":30,
+		"ice":30,
+		"thunder":30,
+		"light":-40,
+		"darkness":80,
+		"bio":-20
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/darkling.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/darkling.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":10,
+		"stab":10,
+		"explosion":10,
+		"magic":15,
+		"projectile":10
+	},
+	
+	"defense_element":{
+		"water":10,
+		"wind":15,
+		"earth":-25,
+		"fire":20,
+		"ice":20,
+		"thunder":20,
+		"light":-60,
+		"darkness":80,
+		"bio":10
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/darkmantle.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/darkmantle.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":15,
+		"stab":15,
+		"explosion":15,
+		"magic":-20,
+		"projectile":10
+	},
+	
+	"defense_element":{
+		"water":35,
+		"wind":-15,
+		"earth":35,
+		"fire":-30,
+		"ice":-30,
+		"thunder":-30,
+		"light":-40,
+		"darkness":80,
+		"bio":50
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/death_dog.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/death_dog.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"stab",
+	"attack_element":"bio",
+	
+	"defense_stlye":{
+		"slash":5,
+		"stab":-5,
+		"explosion":-5,
+		"magic":20,
+		"projectile":-5
+	},
+	
+	"defense_element":{
+		"water":-1,
+		"wind":-1,
+		"earth":-15,
+		"fire":-20,
+		"ice":-10,
+		"thunder":-10,
+		"light":-40,
+		"darkness":110,
+		"bio":45
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/death_kiss.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/death_kiss.json
@@ -1,0 +1,25 @@
+{
+	"attack_style":"magic",
+	"attack_element":"thunder",
+	
+	"defense_stlye":{
+		"slash":35,
+		"stab":35,
+		"explosion":1,
+		"magic":10,
+		"projectile":5
+	},
+	
+	"defense_element":{
+		"light":-10,
+		"thunder":100,
+		"darkness":100,
+		"fire":35,
+		"ice":35,
+		"bio":-35,
+		"wind":-30,
+		"earth":20
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/death_knight.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/death_knight.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"darkness",
+	
+	"defense_stlye":{
+		"slash":25,
+		"stab":25,
+		"explosion":35,
+		"magic":25,
+		"projectile":25
+	},
+	
+	"defense_element":{
+		"water":35,
+		"wind":15,
+		"earth":-25,
+		"fire":45,
+		"ice":15,
+		"thunder":15,
+		"light":110,
+		"darkness":-80,
+		"bio":50
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/death_tyrant.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/death_tyrant.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"stab",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":20,
+		"stab":20,
+		"explosion":20,
+		"magic":65,
+		"projectile":20
+	},
+	
+	"defense_element":{
+		"water":15,
+		"wind":45,
+		"earth":-15,
+		"fire":20,
+		"ice":20,
+		"thunder":-20,
+		"light":-70,
+		"darkness":100,
+		"bio":100
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/deathlock.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/deathlock.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"darkness",
+	
+	"defense_stlye":{
+		"slash":-10,
+		"stab":-5,
+		"explosion":-15,
+		"magic":30,
+		"projectile":25
+	},
+	
+	"defense_element":{
+		"water":-10,
+		"wind":-20,
+		"earth":-20,
+		"fire":20,
+		"ice":20,
+		"thunder":20,
+		"light":-30,
+		"darkness":60,
+		"bio":100
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/deep_scion.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/deep_scion.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":25,
+		"stab":25,
+		"explosion":25,
+		"magic":10,
+		"projectile":15
+	},
+	
+	"defense_element":{
+		"water":65,
+		"wind":-15,
+		"earth":-25,
+		"fire":30,
+		"ice":-10,
+		"thunder":-40,
+		"light":-20,
+		"darkness":40,
+		"bio":30
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/demilich.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/demilich.json
@@ -1,0 +1,21 @@
+{
+	"attack_style":"magic",
+	"attack_element":"darkness",
+	
+	"defense_stlye":{
+		"explosion":5,
+		"magic":25,
+		"projectile":-10
+	},
+	
+	"defense_element":{
+		"ice":50,
+		"thunder":50,
+		"darkness":110,
+		"light":-60,
+		"earth":110,
+		"bio":-20
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/derro.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/derro.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":10,
+		"stab":10,
+		"explosion":10,
+		"magic":25,
+		"projectile":20
+	},
+	
+	"defense_element":{
+		"water":-5,
+		"wind":-15,
+		"earth":15,
+		"fire":10,
+		"ice":10,
+		"thunder":10,
+		"light":-60,
+		"darkness":60,
+		"bio":50
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/destrachan.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/destrachan.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"thunder",
+	
+	"defense_stlye":{
+		"slash":35,
+		"stab":35,
+		"explosion":35,
+		"magic":-15,
+		"projectile":30
+	},
+	
+	"defense_element":{
+		"water":35,
+		"wind":-20,
+		"earth":-35,
+		"fire":25,
+		"ice":10,
+		"thunder":60,
+		"light":-35,
+		"darkness":50,
+		"bio":20
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/displacer_beast.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/displacer_beast.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"basic",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":35,
+		"stab":35,
+		"explosion":35,
+		"magic":5,
+		"projectile":35
+	},
+	
+	"defense_element":{
+		"water":45,
+		"wind":45,
+		"earth":-45,
+		"fire":-10,
+		"ice":30,
+		"thunder":20,
+		"light":-30,
+		"darkness":50,
+		"bio":-40
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/doppleganger.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/doppleganger.json
@@ -1,0 +1,19 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":15,
+		"stab":5,
+		"explosion":5,
+		"magic":-5,
+		"projectile":10
+	},
+	
+	"defense_element":{
+		"darkness":-10,
+		"light":-10
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/draconian.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/draconian.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":15,
+		"stab":15,
+		"explosion":25,
+		"magic":1,
+		"projectile":1
+	},
+	
+	"defense_element":{
+		"water":-25,
+		"wind":1,
+		"earth":15,
+		"fire":50,
+		"ice":5,
+		"thunder":35,
+		"light":-40,
+		"darkness":-40,
+		"bio":20
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/drider.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/drider.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"stab",
+	"attack_element":"bio",
+	
+	"defense_stlye":{
+		"slash":40,
+		"stab":40,
+		"explosion":40,
+		"magic":35,
+		"projectile":30
+	},
+	
+	"defense_element":{
+		"water":25,
+		"wind":15,
+		"earth":25,
+		"fire":-45,
+		"ice":40,
+		"thunder":-10,
+		"light":-30,
+		"darkness":60,
+		"bio":40
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/drow.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/drow.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":15,
+		"stab":15,
+		"explosion":15,
+		"magic":15,
+		"projectile":15
+	},
+	
+	"defense_element":{
+		"water":15,
+		"wind":15,
+		"earth":15,
+		"fire":25,
+		"ice":25,
+		"thunder":25,
+		"light":-25,
+		"darkness":25,
+		"bio":25
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/dryad.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/dryad.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"magic",
+	"attack_element":"bio",
+	
+	"defense_stlye":{
+		"slash":-15,
+		"stab":5,
+		"explosion":15,
+		"magic":35,
+		"projectile":5
+	},
+	
+	"defense_element":{
+		"water":55,
+		"wind":25,
+		"earth":25,
+		"fire":-20,
+		"ice":10,
+		"thunder":-20,
+		"light":70,
+		"darkness":-30,
+		"bio":100
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/duergar.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/duergar.json
@@ -1,0 +1,25 @@
+{
+	"attack_style":"basic",
+	"attack_element":"earth",
+	
+	"defense_stlye":{
+		"slash":13,
+		"stab":13,
+		"explosion":23,
+		"magic":-13,
+		"projectile":13
+	},
+	
+	"defense_element":{
+		"water":25,
+		"wind":25,
+		"earth":55,
+		"fire":25,
+		"ice":25,
+		"thunder":1,
+		"light":25,
+		"darkness":-35
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/duodrone.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/duodrone.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":10,
+		"stab":10,
+		"explosion":15,
+		"magic":-10,
+		"projectile":10
+	},
+	
+	"defense_element":{
+		"water":-15,
+		"wind":-15,
+		"earth":-45,
+		"fire":40,
+		"ice":40,
+		"thunder":20,
+		"light":10,
+		"darkness":10,
+		"bio":100
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/dwarf.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/dwarf.json
@@ -1,0 +1,25 @@
+{
+	"attack_style":"basic",
+	"attack_element":"earth",
+	
+	"defense_stlye":{
+		"slash":5,
+		"stab":5,
+		"explosion":15,
+		"magic":-5,
+		"projectile":5
+	},
+	
+	"defense_element":{
+		"water":15,
+		"wind":15,
+		"earth":35,
+		"fire":15,
+		"ice":15,
+		"thunder":1,
+		"light":25,
+		"darkness":-25
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/eagle.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/eagle.json
@@ -1,0 +1,25 @@
+{
+	"attack_style":"stab",
+	"attack_element":"wind",
+	
+	"defense_stlye":{
+		"slash":1,
+		"stab":1,
+		"explosion":-15,
+		"magic":-5,
+		"projectile":-15
+	},
+	
+	"defense_element":{
+		"water":1,
+		"wind":80,
+		"earth":-40,
+		"fire":1,
+		"ice":1,
+		"thunder":1,
+		"light":-40,
+		"darkness":-30
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/elder_brain.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/elder_brain.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"magic",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":-5,
+		"stab":-5,
+		"explosion":-25,
+		"magic":75,
+		"projectile":-15
+	},
+	
+	"defense_element":{
+		"water":75,
+		"wind":20,
+		"earth":-20,
+		"fire":10,
+		"ice":10,
+		"thunder":-30,
+		"light":50,
+		"darkness":50,
+		"bio":-20
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/elf.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/elf.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":5,
+		"stab":5,
+		"explosion":1,
+		"magic":15,
+		"projectile":1
+	},
+	
+	"defense_element":{
+		"water":15,
+		"wind":15,
+		"earth":15,
+		"fire":15,
+		"ice":15,
+		"thunder":15,
+		"light":15,
+		"darkness":15,
+		"bio":15
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/ent.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/ent.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"bio",
+	
+	"defense_stlye":{
+		"slash":55,
+		"stab":55,
+		"explosion":55,
+		"magic":40,
+		"projectile":-10
+	},
+	
+	"defense_element":{
+		"water":45,
+		"wind":15,
+		"earth":25,
+		"fire":-45,
+		"ice":-15,
+		"thunder":-25,
+		"light":70,
+		"darkness":-35,
+		"bio":100
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletacid_attack.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletacid_attack.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"bio",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletagility_spell.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletagility_spell.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"light",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletamber_hand_axe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletamber_hand_axe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletamber_spear.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletamber_spear.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"stab",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletamethyst_hand_axe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletamethyst_hand_axe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletamethyst_spear.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletamethyst_spear.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"stab",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletandrosphinx_roar.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletandrosphinx_roar.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"thunder",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletaquamarine_hand_axe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletaquamarine_hand_axe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletaquamarine_spear.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletaquamarine_spear.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"stab",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletaquatic_grace_spell.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletaquatic_grace_spell.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"water",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletarcane_explosion.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletarcane_explosion.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"light",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletarcane_missile_spell.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletarcane_missile_spell.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"light",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletbad_luck.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletbad_luck.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletbeholders_eye.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletbeholders_eye.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletblink_spell.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletblink_spell.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletbomb.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletbomb.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"fire",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletboulder_spell.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletboulder_spell.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"earth",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletclear_weather_spell.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletclear_weather_spell.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletcockatrice_vision.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletcockatrice_vision.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"darkness",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletcopper_hand_axe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletcopper_hand_axe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletcopper_spear.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletcopper_spear.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"stab",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletdeathlock_spell.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletdeathlock_spell.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"ice",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletdemilich_drain_spel.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletdemilich_drain_spel.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"darkness",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletdestrachan_blast.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletdestrachan_blast.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"wind",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletdiamond_hand_axe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletdiamond_hand_axe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletdiamond_spear.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletdiamond_spear.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"stab",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletdragons_breath.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletdragons_breath.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"fire",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletdragonsacid_breath.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletdragonsacid_breath.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"bio",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletelf.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletelf.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"stab",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletemerald_hand_axe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletemerald_hand_axe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletemerald_spear.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletemerald_spear.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"stab",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulleteuphoria_breath.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulleteuphoria_breath.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"light",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletextreme_speed_spell.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletextreme_speed_spell.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulleteyeofthe_deep_ray.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulleteyeofthe_deep_ray.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"thunder",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulleteyeray.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulleteyeray.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"darkness",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletfeather_fall_spell.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletfeather_fall_spell.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletfire_breath_spell.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletfire_breath_spell.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"fire",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletfireball_spell.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletfireball_spell.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"fire",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletfirebolt.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletfirebolt.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"fire",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletflood_spell.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletflood_spell.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"water",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletforce_beam_spell.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletforce_beam_spell.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"wind",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletfreeze.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletfreeze.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"ice",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletfrost_breath.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletfrost_breath.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"ice",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletfrostball_spell.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletfrostball_spell.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"ice",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletfrostbolt.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletfrostbolt.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"ice",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletgiff_musket_item.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletgiff_musket_item.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"stab",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletglow_spell.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletglow_spell.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"light",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletgold_hand_axe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletgold_hand_axe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletgold_spear.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletgold_spear.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"stab",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletgrave_bolt_spell.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletgrave_bolt_spell.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"darkness",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletgreater_fireball_spell.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletgreater_fireball_spell.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"fire",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletgreater_heal_spell.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletgreater_heal_spell.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"light",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletgreater_ice_spikes_spell.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletgreater_ice_spikes_spell.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"ice",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletgrell_lightning.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletgrell_lightning.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"thunder",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybullethag_spell.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybullethag_spell.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"darkness",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletheal.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletheal.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"light",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletice_spikes_spell.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletice_spikes_spell.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"ice",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletillithid_spell.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletillithid_spell.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletinvisbility_spell.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletinvisbility_spell.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"light",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletiron_hand_axe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletiron_hand_axe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletiron_spear.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletiron_spear.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"stab",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletironskin_spell.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletironskin_spell.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"earth",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletjade_hand_axe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletjade_hand_axe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletjade_spear.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletjade_spear.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"stab",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletlead_hand_axe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletlead_hand_axe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletlead_spear.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletlead_spear.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"stab",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletlich_spell.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletlich_spell.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"darkness",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletlife_drain.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletlife_drain.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"bio",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletlightning.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletlightning.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"thunder",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletluck.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletluck.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletmage_armor_spell.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletmage_armor_spell.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletmagic_missile.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletmagic_missile.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"light",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletmedusasight.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletmedusasight.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"earth",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletmeteor_spell.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletmeteor_spell.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"fire",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletmicroeyeray.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletmicroeyeray.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"darkness",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletmind_blast.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletmind_blast.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"bio",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletminifireball.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletminifireball.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"fire",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletnecroticbolt.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletnecroticbolt.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"darkness",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletnickel_hand_axe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletnickel_hand_axe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletnickel_spear.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletnickel_spear.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"stab",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletnothic_beam.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletnothic_beam.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"darkness",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletoathbow.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletoathbow.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletonyx_hand_axe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletonyx_hand_axe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletonyx_spear.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletonyx_spear.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"stab",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletperidot_hand_axe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletperidot_hand_axe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletperidot_spear.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletperidot_spear.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"stab",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletplatinum_spear.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletplatinum_spear.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"stab",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletrain_spell.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletrain_spell.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"water",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletrayof_sickness_spell.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletrayof_sickness_spell.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"darkness",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletrestoration_spell.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletrestoration_spell.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"light",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletruby_hand_axe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletruby_hand_axe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletruby_spear.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletruby_spear.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"stab",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletsapphire_hand_axe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletsapphire_hand_axe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletsapphire_spear.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletsapphire_spear.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"stab",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletsaturate.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletsaturate.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"water",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletsatyr.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletsatyr.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"stab",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletshadow_ball_spell.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletshadow_ball_spell.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"darkness",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletsilver_hand_axe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletsilver_hand_axe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletsilver_spear.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletsilver_spear.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"stab",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletsleep_spell.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletsleep_spell.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletsmoke_bomb.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletsmoke_bomb.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"basic",
+	"attack_element":"wind",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletsonic_blast_spell.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletsonic_blast_spell.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"wind",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletspore_spell.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletspore_spell.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"bio",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_acid_bolt.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_acid_bolt.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"bio",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_agility.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_agility.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_aquatic_grace.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_aquatic_grace.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"water",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_arcane_explosion.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_arcane_explosion.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"light",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_arcane_missile.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_arcane_missile.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"light",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_bad_luck.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_bad_luck.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"darkness",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_blink.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_blink.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_bomb.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_bomb.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"fire",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_boulder.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_boulder.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"earth",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_clear_weather.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_clear_weather.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_electric_bolt.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_electric_bolt.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"thunder",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_extreme_speed.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_extreme_speed.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_featherfall.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_featherfall.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_fire_breath.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_fire_breath.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"fire",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_fireball.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_fireball.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"fire",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_firebolt.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_firebolt.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"fire",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_flood.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_flood.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"water",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_freeze.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_freeze.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"ice",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_frostball.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_frostball.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"ice",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_frostbolt.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_frostbolt.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"ice",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_glow.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_glow.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"light",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_greater_fireball.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_greater_fireball.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"fire",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_greater_heal.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_greater_heal.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"light",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_greater_ice_spikes.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_greater_ice_spikes.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"ice",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_heal.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_heal.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"heal",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_ice_spikes.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_ice_spikes.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"ice",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_invisibility.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_invisibility.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"light",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_ironskin.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_ironskin.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"earth",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_life_drain.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_life_drain.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"darkness",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_lightning.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_lightning.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"thunder",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_luck.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_luck.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_mage_armor.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_mage_armor.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_magic_missile.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_magic_missile.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_meteor.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_meteor.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"fire",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_mind_blast.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_mind_blast.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_necroticbolt.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_necroticbolt.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"darkness",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_rain.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_rain.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"water",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_rayof_sickness.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_rayof_sickness.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"darkness",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_restoration.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_restoration.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"heal",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_saturate.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_saturate.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"water",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_shadow_ball.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_shadow_ball.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"darkness",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_sleep.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_sleep.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"light",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_sonic_blast.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_sonic_blast.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"wind",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_spore.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_spore.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"bio",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_starstrike.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_starstrike.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"light",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_stun.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_stun.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"thunder",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_teleport.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_teleport.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_thunder_storm.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_thunder_storm.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"thunder",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_wave.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_wave.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"wind",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_web.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstaffof_web.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"bio",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstarstrike_spell.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstarstrike_spell.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"light",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstone_hand_a_xe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstone_hand_a_xe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstone_spear.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstone_spear.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"stab",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstun_spell.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletstun_spell.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"thunder",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletteleport_spell.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletteleport_spell.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletthrowing_dagger.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletthrowing_dagger.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"stab",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletthunder_storm.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletthunder_storm.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"lightning",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybullettin_hand_axe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybullettin_hand_axe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybullettin_spear.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybullettin_spear.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"stab",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybullettopaz_hand_axe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybullettopaz_hand_axe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybullettopaz_spear.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybullettopaz_spear.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"stab",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletturquoise_hand_axe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletturquoise_hand_axe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletturquoise_spear.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletturquoise_spear.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"stab",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletwave.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletwave.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"wind",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletweb_spell.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitybulletweb_spell.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"bio",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/entitydryad_entangle.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/entitydryad_entangle.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"basic",
+	"attack_element":"bio",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/ettercap.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/ettercap.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"stab",
+	"attack_element":"bio",
+	
+	"defense_stlye":{
+		"slash":15,
+		"stab":15,
+		"explosion":55,
+		"magic":-5,
+		"projectile":25
+	},
+	
+	"defense_element":{
+		"water":15,
+		"wind":-5,
+		"earth":25,
+		"fire":-50,
+		"ice":10,
+		"thunder":-20,
+		"light":-10,
+		"darkness":50,
+		"bio":50
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/ettin.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/ettin.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"earth",
+	
+	"defense_stlye":{
+		"slash":35,
+		"stab":35,
+		"explosion":45,
+		"magic":-20,
+		"projectile":-10
+	},
+	
+	"defense_element":{
+		"water":10,
+		"wind":-30,
+		"earth":45,
+		"fire":10,
+		"ice":-20,
+		"thunder":10,
+		"light":-30,
+		"darkness":60,
+		"bio":10
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/extremely_tiny_black_pudding.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/extremely_tiny_black_pudding.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"bio",
+	
+	"defense_stlye":{
+		"slash":100,
+		"stab":1,
+		"explosion":1,
+		"magic":-25,
+		"projectile":1
+	},
+	
+	"defense_element":{
+		"water":25,
+		"wind":25,
+		"earth":25,
+		"fire":-50,
+		"ice":100,
+		"thunder":100,
+		"light":10,
+		"darkness":10,
+		"bio":100
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/eye_of_the_deep.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/eye_of_the_deep.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":40,
+		"stab":40,
+		"explosion":40,
+		"magic":95,
+		"projectile":20
+	},
+	
+	"defense_element":{
+		"water":-35,
+		"wind":75,
+		"earth":35,
+		"fire":50,
+		"ice":-10,
+		"thunder":50,
+		"light":-30,
+		"darkness":50,
+		"bio":-75
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/faerie_dragon.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/faerie_dragon.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"stab",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":15,
+		"stab":15,
+		"explosion":15,
+		"magic":55,
+		"projectile":50
+	},
+	
+	"defense_element":{
+		"water":5,
+		"wind":35,
+		"earth":5,
+		"fire":25,
+		"ice":10,
+		"thunder":5,
+		"light":20,
+		"darkness":-20,
+		"bio":15
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/fake_berbalang.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/fake_berbalang.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"stab",
+	"attack_element":"bio",
+	
+	"defense_stlye":{
+		"slash":30,
+		"stab":30,
+		"explosion":30,
+		"magic":40,
+		"projectile":10
+	},
+	
+	"defense_element":{
+		"water":35,
+		"wind":-15,
+		"earth":15,
+		"fire":50,
+		"ice":50,
+		"thunder":50,
+		"light":25,
+		"darkness":25,
+		"bio":30
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/fake_cloaker.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/fake_cloaker.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":1,
+		"stab":1,
+		"explosion":15,
+		"magic":25,
+		"projectile":1
+	},
+	
+	"defense_element":{
+		"water":-15,
+		"wind":-15,
+		"earth":-15,
+		"fire":50,
+		"ice":50,
+		"thunder":50,
+		"light":-20,
+		"darkness":-20,
+		"bio":50
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/fake_doppleganger.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/fake_doppleganger.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"stab",
+	"attack_element":"bio",
+	
+	"defense_stlye":{
+		"slash":30,
+		"stab":30,
+		"explosion":30,
+		"magic":40,
+		"projectile":10
+	},
+	
+	"defense_element":{
+		"water":35,
+		"wind":-15,
+		"earth":15,
+		"fire":50,
+		"ice":50,
+		"thunder":50,
+		"light":25,
+		"darkness":25,
+		"bio":30
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/fake_rakshasa.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/fake_rakshasa.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":1,
+		"stab":1,
+		"explosion":15,
+		"magic":25,
+		"projectile":1
+	},
+	
+	"defense_element":{
+		"water":-15,
+		"wind":-15,
+		"earth":-15,
+		"fire":50,
+		"ice":50,
+		"thunder":50,
+		"light":-20,
+		"darkness":-20,
+		"bio":50
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/falling_star.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/falling_star.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"bio",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/fire_beetle.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/fire_beetle.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"fire",
+	
+	"defense_stlye":{
+		"slash":10,
+		"stab":10,
+		"explosion":10,
+		"magic":-35,
+		"projectile":1
+	},
+	
+	"defense_element":{
+		"water":-40,
+		"wind":25,
+		"earth":25,
+		"fire":60,
+		"ice":-20,
+		"thunder":50,
+		"light":30,
+		"darkness":10,
+		"bio":30
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/fire_snake.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/fire_snake.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"stab",
+	"attack_element":"fire",
+	
+	"defense_stlye":{
+		"slash":20,
+		"stab":20,
+		"explosion":20,
+		"magic":-15,
+		"projectile":20
+	},
+	
+	"defense_element":{
+		"water":-25,
+		"wind":10,
+		"earth":25,
+		"fire":100,
+		"ice":-50,
+		"thunder":40,
+		"light":-30,
+		"darkness":50,
+		"bio":50
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/firenewt.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/firenewt.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"magic",
+	"attack_element":"fire",
+	
+	"defense_stlye":{
+		"slash":1,
+		"stab":1,
+		"explosion":15,
+		"magic":25,
+		"projectile":1
+	},
+	
+	"defense_element":{
+		"water":1,
+		"wind":15,
+		"earth":15,
+		"fire":100,
+		"ice":-45,
+		"thunder":1,
+		"light":-40,
+		"darkness":40,
+		"bio":10
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/flail_snail.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/flail_snail.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"light",
+	
+	"defense_stlye":{
+		"slash":50,
+		"stab":50,
+		"explosion":50,
+		"magic":-25,
+		"projectile":-25
+	},
+	
+	"defense_element":{
+		"water":-45,
+		"wind":-45,
+		"earth":-25,
+		"fire":100,
+		"ice":50,
+		"thunder":10,
+		"light":40,
+		"darkness":20,
+		"bio":100
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/flameskull.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/flameskull.json
@@ -1,0 +1,22 @@
+{
+	"attack_style":"magic",
+	"attack_element":"fire",
+	
+	"defense_stlye":{
+		"slash":-20,
+		"magic":-20,
+		"stab":100,
+		"explosion":30,
+		"projectile":100
+	},
+	
+	"defense_element":{
+		"darkness":50,
+		"thunder":50,
+		"ice":100,
+		"fire":100,
+		"bio":100
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/flumph.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/flumph.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"magic",
+	"attack_element":"bio",
+	
+	"defense_stlye":{
+		"slash":-15,
+		"stab":-15,
+		"explosion":-25,
+		"magic":55,
+		"projectile":-35
+	},
+	
+	"defense_element":{
+		"water":25,
+		"wind":25,
+		"earth":25,
+		"fire":25,
+		"ice":25,
+		"thunder":25,
+		"light":-20,
+		"darkness":-20,
+		"bio":50
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/flying_snake.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/flying_snake.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"stab",
+	"attack_element":"bio",
+	
+	"defense_stlye":{
+		"slash":5,
+		"stab":5,
+		"explosion":15,
+		"magic":10,
+		"projectile":5
+	},
+	
+	"defense_element":{
+		"water":-15,
+		"wind":-15,
+		"earth":-15,
+		"fire":20,
+		"ice":10,
+		"thunder":10,
+		"light":-20,
+		"darkness":-20,
+		"bio":50
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/flying_sword.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/flying_sword.json
@@ -1,0 +1,22 @@
+{
+	"attack_style":"slash",
+	"attack_element":"wind",
+	
+	"defense_stlye":{
+        "slash":1,
+        "stab":1,
+		"explosion":1,
+		"projectile":1,
+		"magic":-40
+	},
+	
+	"defense_element":{
+		"fire":-5,
+		"wind":80,
+		"thunder":20,
+		"light":-30,
+		"darkness":-20
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/fomorian.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/fomorian.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"darkness",
+	
+	"defense_stlye":{
+		"slash":50,
+		"stab":50,
+		"explosion":50,
+		"magic":15,
+		"projectile":0
+	},
+	
+	"defense_element":{
+		"water":-25,
+		"wind":-55,
+		"earth":85,
+		"fire":20,
+		"ice":20,
+		"thunder":20,
+		"light":-40,
+		"darkness":80,
+		"bio":20
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/four_headed_hydra.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/four_headed_hydra.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"stab",
+	"attack_element":"water",
+	
+	"defense_stlye":{
+		"slash":50,
+		"stab":50,
+		"explosion":60,
+		"magic":-40,
+		"projectile":10
+	},
+	
+	"defense_element":{
+		"water":40,
+		"wind":20,
+		"earth":-20,
+		"fire":20,
+		"ice":20,
+		"thunder":-40,
+		"light":25,
+		"darkness":25,
+		"bio":20
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/frog.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/frog.json
@@ -1,0 +1,22 @@
+{
+	"attack_style":"basic",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":5,
+		"stab":5,
+		"explosion":1,
+		"magic":-1,
+		"projectile":3
+	},
+	
+	"defense_element":{
+		"water":40,
+		"wind":20,
+		"earth":-50,
+		"fire":10,
+		"ice":-60
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/froghemoth.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/froghemoth.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"water",
+	
+	"defense_stlye":{
+		"slash":50,
+		"stab":50,
+		"explosion":50,
+		"magic":30,
+		"projectile":15
+	},
+	
+	"defense_element":{
+		"water":65,
+		"wind":-10,
+		"earth":15,
+		"fire":30,
+		"ice":20,
+		"thunder":-25,
+		"light":30,
+		"darkness":30,
+		"bio":65
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/galeb_durr.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/galeb_durr.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"earth",
+	
+	"defense_stlye":{
+		"slash":50,
+		"stab":50,
+		"explosion":50,
+		"magic":15,
+		"projectile":20
+	},
+	
+	"defense_element":{
+		"water":-40,
+		"wind":-55,
+		"earth":75,
+		"fire":-10,
+		"ice":20,
+		"thunder":20,
+		"light":10,
+		"darkness":10,
+		"bio":100
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/gargoyle.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/gargoyle.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"earth",
+	
+	"defense_stlye":{
+		"slash":30,
+		"stab":30,
+		"explosion":30,
+		"magic":-15,
+		"projectile":5
+	},
+	
+	"defense_element":{
+		"water":5,
+		"wind":-15,
+		"earth":25,
+		"fire":-15,
+		"ice":-15,
+		"thunder":-15,
+		"light":-20,
+		"darkness":-20,
+		"bio":25
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/gas_spore.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/gas_spore.json
@@ -1,0 +1,20 @@
+{
+	"attack_style":"basic",
+	"attack_element":"bio",
+	
+	"defense_stlye":{
+		"slash":50,
+		"stab":35,
+		"explosion":30,
+		"magic":-20,
+		"projectile":20
+	},
+	
+	"defense_element":{
+		"bio":100,
+		"light":-30,
+		"darkness":30
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/gauth.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/gauth.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"magic",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":30,
+		"stab":30,
+		"explosion":35,
+		"magic":25,
+		"projectile":5
+	},
+	
+	"defense_element":{
+		"water":25,
+		"wind":25,
+		"earth":25,
+		"fire":30,
+		"ice":-20,
+		"thunder":-30,
+		"light":-30,
+		"darkness":60,
+		"bio":10
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/gazer.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/gazer.json
@@ -1,0 +1,22 @@
+{
+	"attack_style":"magic",
+	"attack_element":"light",
+	
+	"defense_stlye":{
+		"slash":10,
+		"stab":10,
+		"explosion":-5,
+		"magic":5,
+		"projectile":-10
+	},
+	
+	"defense_element":{
+		"darkness":50,
+		"light":-20,
+		"fire":-50,
+		"thunder":-50,
+		"ice":-50
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/gelatinous_cube.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/gelatinous_cube.json
@@ -1,0 +1,18 @@
+{
+	"attack_style":"basic",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":25,
+		"stab":25,
+		"explosion":-5,
+		"magic":-10,
+		"projectile":25
+	},
+	
+	"defense_element":{
+		"fire":-30
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/ghast.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/ghast.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"stab",
+	"attack_element":"bio",
+	
+	"defense_stlye":{
+		"slash":5,
+		"stab":5,
+		"explosion":5,
+		"magic":5,
+		"projectile":5
+	},
+	
+	"defense_element":{
+		"water":1,
+		"wind":30,
+		"earth":-10,
+		"fire":-25,
+		"ice":1,
+		"thunder":1,
+		"light":-40,
+		"darkness":50,
+		"bio":100
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/ghost.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/ghost.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"magic",
+	"attack_element":"darkness",
+	
+	"defense_stlye":{
+		"slash":75,
+		"stab":75,
+		"explosion":80,
+		"magic":5,
+		"projectile":75
+	},
+	
+	"defense_element":{
+		"water":50,
+		"wind":50,
+		"earth":-40,
+		"fire":50,
+		"ice":100,
+		"thunder":50,
+		"light":-75,
+		"darkness":100,
+		"bio":100
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/ghoul.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/ghoul.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"stab",
+	"attack_element":"darkness",
+	
+	"defense_stlye":{
+		"slash":5,
+		"stab":5,
+		"explosion":5,
+		"magic":-5,
+		"projectile":5
+	},
+	
+	"defense_element":{
+		"water":1,
+		"wind":30,
+		"earth":-10,
+		"fire":1,
+		"ice":1,
+		"thunder":1,
+		"light":-40,
+		"darkness":80,
+		"bio":100
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/giant_strider.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/giant_strider.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"stab",
+	"attack_element":"fire",
+	
+	"defense_stlye":{
+		"slash":20,
+		"stab":20,
+		"explosion":20,
+		"magic":-20,
+		"projectile":15
+	},
+	
+	"defense_element":{
+		"water":-25,
+		"wind":5,
+		"earth":15,
+		"fire":150,
+		"ice":-10,
+		"thunder":35,
+		"light":-30,
+		"darkness":-50,
+		"bio":20
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/gibbering_mouther.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/gibbering_mouther.json
@@ -1,0 +1,15 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":10,
+		"stab":5,
+		"explosion":-5
+	},
+	
+	"defense_element":{
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/giff.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/giff.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":35,
+		"stab":35,
+		"explosion":35,
+		"magic":15,
+		"projectile":20
+	},
+	
+	"defense_element":{
+		"water":5,
+		"wind":-15,
+		"earth":30,
+		"fire":15,
+		"ice":5,
+		"thunder":5,
+		"light":30,
+		"darkness":30,
+		"bio":5
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/girallon.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/girallon.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":30,
+		"stab":30,
+		"explosion":30,
+		"magic":-15,
+		"projectile":30
+	},
+	
+	"defense_element":{
+		"water":15,
+		"wind":25,
+		"earth":35,
+		"fire":-30,
+		"ice":-20,
+		"thunder":-20,
+		"light":10,
+		"darkness":10,
+		"bio":40
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/githyanki.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/githyanki.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":5,
+		"stab":5,
+		"explosion":5,
+		"magic":5,
+		"projectile":5
+	},
+	
+	"defense_element":{
+		"water":-20,
+		"wind":-20,
+		"earth":-20,
+		"fire":-20,
+		"ice":-20,
+		"thunder":-20,
+		"light":-20,
+		"darkness":40,
+		"bio":10
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/gnoll.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/gnoll.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"stab",
+	"attack_element":"darkness",
+	
+	"defense_stlye":{
+		"slash":1,
+		"stab":1,
+		"explosion":1,
+		"magic":1,
+		"projectile":1
+	},
+	
+	"defense_element":{
+		"water":1,
+		"wind":1,
+		"earth":1,
+		"fire":1,
+		"ice":1,
+		"thunder":1,
+		"light":-55,
+		"darkness":75,
+		"bio":25
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/gnome.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/gnome.json
@@ -1,0 +1,25 @@
+{
+	"attack_style":"stab",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":1,
+		"stab":1,
+		"explosion":-45,
+		"magic":55,
+		"projectile":1
+	},
+	
+	"defense_element":{
+		"water":1,
+		"wind":10,
+		"earth":-50,
+		"fire":15,
+		"ice":15,
+		"thunder":15,
+		"light":50,
+		"darkness":-20
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/goblin.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/goblin.json
@@ -1,0 +1,21 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":5,
+		"stab":5,
+		"explosion":-5,
+		"magic":-5,
+		"projectile":-5
+	},
+	
+	"defense_element":{
+		"fire":-10,
+		"thunder":-10,
+		"darkness":10,
+		"light":-10
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/goblin_bomber.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/goblin_bomber.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"fire",
+	
+	"defense_stlye":{
+		"slash":20,
+		"stab":20,
+		"explosion":20,
+		"magic":40,
+		"projectile":40
+	},
+	
+	"defense_element":{
+		"water":-30,
+		"wind":15,
+		"earth":15,
+		"fire":100,
+		"ice":30,
+		"thunder":-30,
+		"light":-30,
+		"darkness":50,
+		"bio":30
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/goblin_chief.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/goblin_chief.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":1,
+		"stab":1,
+		"explosion":1,
+		"magic":-10,
+		"projectile":20
+	},
+	
+	"defense_element":{
+		"water":15,
+		"wind":15,
+		"earth":15,
+		"fire":10,
+		"ice":20,
+		"thunder":10,
+		"light":-30,
+		"darkness":70,
+		"bio":10
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/gorgon.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/gorgon.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"stab",
+	"attack_element":"earth",
+	
+	"defense_stlye":{
+		"slash":40,
+		"stab":40,
+		"explosion":50,
+		"magic":-20,
+		"projectile":45
+	},
+	
+	"defense_element":{
+		"water":15,
+		"wind":5,
+		"earth":45,
+		"fire":-20,
+		"ice":-30,
+		"thunder":-10,
+		"light":10,
+		"darkness":10,
+		"bio":20
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/gouger.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/gouger.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"stab",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":-15,
+		"stab":15,
+		"explosion":-15,
+		"magic":25,
+		"projectile":-5
+	},
+	
+	"defense_element":{
+		"water":-15,
+		"wind":-15,
+		"earth":-15,
+		"fire":50,
+		"ice":50,
+		"thunder":50,
+		"light":-20,
+		"darkness":-20,
+		"bio":50
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/gray_ooze.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/gray_ooze.json
@@ -1,0 +1,20 @@
+{
+	"attack_style":"basic",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":10,
+		"stab":10,
+		"explosion":-5,
+		"magic":-15,
+		"projectile":10
+	},
+	
+	"defense_element":{
+		"bio":50,
+		"ice":50,
+		"fire":50
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/green_goblin.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/green_goblin.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":0,
+		"stab":0,
+		"explosion":0,
+		"magic":-10,
+		"projectile":20
+	},
+	
+	"defense_element":{
+		"water":10,
+		"wind":10,
+		"earth":-10,
+		"fire":-20,
+		"ice":20,
+		"thunder":20,
+		"light":-30,
+		"darkness":50,
+		"bio":20
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/green_hag.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/green_hag.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"light",
+	
+	"defense_stlye":{
+		"slash":25,
+		"stab":25,
+		"explosion":25,
+		"magic":-10,
+		"projectile":25
+	},
+	
+	"defense_element":{
+		"water":35,
+		"wind":25,
+		"earth":15,
+		"fire":10,
+		"ice":10,
+		"thunder":20,
+		"light":60,
+		"darkness":-50,
+		"bio":20
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/grell.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/grell.json
@@ -1,0 +1,21 @@
+{
+	"attack_style":"stab",
+	"attack_element":"thunder",
+	
+	"defense_stlye":{
+		"slash":-5,
+		"stab":-5,
+		"explosion":-15,
+		"magic":25,
+		"projectile":-10
+	},
+	
+	"defense_element":{
+		"fire":15,
+		"thunder":100,
+		"darkness":25,
+		"light":-25
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/grick.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/grick.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"bio",
+	
+	"defense_stlye":{
+		"slash":5,
+		"stab":5,
+		"explosion":5,
+		"magic":-15,
+		"projectile":20
+	},
+	
+	"defense_element":{
+		"water":25,
+		"wind":-15,
+		"earth":-15,
+		"fire":10,
+		"ice":10,
+		"thunder":-20,
+		"light":10,
+		"darkness":10,
+		"bio":20
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/griffin.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/griffin.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"wind",
+	
+	"defense_stlye":{
+		"slash":30,
+		"stab":30,
+		"explosion":30,
+		"magic":-25,
+		"projectile":25
+	},
+	
+	"defense_element":{
+		"water":15,
+		"wind":25,
+		"earth":15,
+		"fire":10,
+		"ice":5,
+		"thunder":-10,
+		"light":25,
+		"darkness":25,
+		"bio":-25
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/grimlock.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/grimlock.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":5,
+		"stab":5,
+		"explosion":10,
+		"magic":-5,
+		"projectile":5
+	},
+	
+	"defense_element":{
+		"water":15,
+		"wind":25,
+		"earth":35,
+		"fire":10,
+		"ice":20,
+		"thunder":20,
+		"light":-40,
+		"darkness":80,
+		"bio":20
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/grung.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/grung.json
@@ -1,0 +1,22 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":15,
+		"stab":5,
+		"explosion":5,
+		"magic":-5,
+		"projectile":5
+	},
+	
+	"defense_element":{
+		"water":75,
+		"bio":60,
+		"earth":-30,
+		"fire":25,
+		"ice":-30
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/half_dragon.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/half_dragon.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":30,
+		"stab":30,
+		"explosion":30,
+		"magic":10,
+		"projectile":25
+	},
+	
+	"defense_element":{
+		"water":25,
+		"wind":15,
+		"earth":-35,
+		"fire":50,
+		"ice":50,
+		"thunder":50,
+		"light":10,
+		"darkness":10,
+		"bio":20
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/hammerhead_shark.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/hammerhead_shark.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"water",
+	
+	"defense_stlye":{
+		"slash":25,
+		"stab":-15,
+		"explosion":15,
+		"magic":15,
+		"projectile":-5
+	},
+	
+	"defense_element":{
+		"water":75,
+		"wind":-25,
+		"earth":-35,
+		"fire":50,
+		"ice":10,
+		"thunder":-60,
+		"light":10,
+		"darkness":10,
+		"bio":10
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/harpy.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/harpy.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":5,
+		"stab":-15,
+		"explosion":5,
+		"magic":5,
+		"projectile":-25
+	},
+	
+	"defense_element":{
+		"water":-15,
+		"wind":65,
+		"earth":25,
+		"fire":-30,
+		"ice":-10,
+		"thunder":10,
+		"light":40,
+		"darkness":-30,
+		"bio":-20
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/headless_horseman.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/headless_horseman.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"ice",
+	
+	"defense_stlye":{
+		"slash":50,
+		"stab":50,
+		"explosion":50,
+		"magic":0,
+		"projectile":30
+	},
+	
+	"defense_element":{
+		"water":20,
+		"wind":10,
+		"earth":10,
+		"fire":-30,
+		"ice":100,
+		"thunder":-10,
+		"light":20,
+		"darkness":55,
+		"bio":50
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/hell_hound.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/hell_hound.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"fire",
+	
+	"defense_stlye":{
+		"slash":-5,
+		"stab":-15,
+		"explosion":-15,
+		"magic":-15,
+		"projectile":-5
+	},
+	
+	"defense_element":{
+		"water":-45,
+		"wind":35,
+		"earth":-35,
+		"fire":80,
+		"ice":10,
+		"thunder":30,
+		"light":-30,
+		"darkness":30,
+		"bio":10
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/helmed_horror.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/helmed_horror.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":50,
+		"stab":50,
+		"explosion":100,
+		"magic":50,
+		"projectile":50
+	},
+	
+	"defense_element":{
+		"water":-120,
+		"wind":-120,
+		"earth":-120,
+		"fire":100,
+		"ice":100,
+		"thunder":100,
+		"light":-50,
+		"darkness":100,
+		"bio":100
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/hill_giant.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/hill_giant.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"earth",
+	
+	"defense_stlye":{
+		"slash":45,
+		"stab":45,
+		"explosion":55,
+		"magic":-45,
+		"projectile":-20
+	},
+	
+	"defense_element":{
+		"water":-5,
+		"wind":-35,
+		"earth":85,
+		"fire":30,
+		"ice":30,
+		"thunder":30,
+		"light":-40,
+		"darkness":80,
+		"bio":5
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/hill_troll.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/hill_troll.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"earth",
+	
+	"defense_stlye":{
+		"slash":50,
+		"stab":50,
+		"explosion":50,
+		"magic": -20,
+		"projectile":15
+	},
+	
+	"defense_element":{
+		"water":-15,
+		"wind":-25,
+		"earth":50,
+		"fire":25,
+		"ice":-10,
+		"thunder":-10,
+		"light":-30,
+		"darkness":60,
+		"bio":25
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/hippogriff.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/hippogriff.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"stab",
+	"attack_element":"wind",
+	
+	"defense_stlye":{
+		"slash":-15,
+		"stab":-15,
+		"explosion":-15,
+		"magic":15,
+		"projectile":-20
+	},
+	
+	"defense_element":{
+		"water":10,
+		"wind":75,
+		"earth":35,
+		"fire":10,
+		"ice":10,
+		"thunder":-50,
+		"light":50,
+		"darkness":50,
+		"bio":10
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/hobgoblin.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/hobgoblin.json
@@ -1,0 +1,25 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":10,
+		"stab":10,
+		"explosion":25,
+		"magic":-20,
+		"projectile":5
+	},
+	
+	"defense_element":{
+		"water":1,
+		"wind":20,
+		"earth":30,
+		"fire":1,
+		"ice":-30,
+		"thunder":-40,
+		"light":-50,
+		"darkness":40
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/hook_horror.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/hook_horror.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"stab",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":25,
+		"stab":25,
+		"explosion":25,
+		"magic":-5,
+		"projectile":0
+	},
+	
+	"defense_element":{
+		"water":25,
+		"wind":-40,
+		"earth":-15,
+		"fire":10,
+		"ice":10,
+		"thunder":-20,
+		"light":-20,
+		"darkness":30,
+		"bio":10
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/human.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/human.json
@@ -1,0 +1,25 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":1,
+		"stab":-15,
+		"explosion":15,
+		"magic":1,
+		"projectile":-25
+	},
+	
+	"defense_element":{
+		"water":1,
+		"wind":1,
+		"earth":10,
+		"fire":1,
+		"ice":1,
+		"thunder":1,
+		"light":10,
+		"darkness":10
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/hydra.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/hydra.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"stab",
+	"attack_element":"water",
+	
+	"defense_stlye":{
+		"slash":50,
+		"stab":50,
+		"explosion":50,
+		"magic":-40,
+		"projectile":10
+	},
+	
+	"defense_element":{
+		"water":75,
+		"wind":-25,
+		"earth":-5,
+		"fire":20,
+		"ice":10,
+		"thunder":-45,
+		"light":20,
+		"darkness":20,
+		"bio":50
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/illithid.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/illithid.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"magic",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":1,
+		"stab":1,
+		"explosion":15,
+		"magic":75,
+		"projectile":1
+	},
+	
+	"defense_element":{
+		"water":1,
+		"wind":1,
+		"earth":-25,
+		"fire":25,
+		"ice":25,
+		"thunder":25,
+		"light":-30,
+		"darkness":30,
+		"bio":-40
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/intellect_devourerer.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/intellect_devourerer.json
@@ -1,0 +1,23 @@
+{
+	"attack_style":"magic",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+        "slash":50,
+        "stab":50,
+		"explosion":25,
+		"magic":-30,
+		"projectile":50
+	},
+	
+	"defense_element":{
+		"fire":-10,
+		"ice":20,
+		"thunder":-50,
+		"darkness":-20,
+		"light":-20,
+		"water":30
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/jackalwere.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/jackalwere.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":75,
+		"stab":75,
+		"explosion":75,
+		"magic":5,
+		"projectile":40
+	},
+	
+	"defense_element":{
+		"water":-5,
+		"wind":-5,
+		"earth":-25,
+		"fire":-30,
+		"ice":-20,
+		"thunder":-30,
+		"light":-60,
+		"darkness":80,
+		"bio":20
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/jackalwere_day.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/jackalwere_day.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"stab",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":25,
+		"stab":25,
+		"explosion":25,
+		"magic":15,
+		"projectile":5
+	},
+	
+	"defense_element":{
+		"water":15,
+		"wind":25,
+		"earth":35,
+		"fire":20,
+		"ice":20,
+		"thunder":10,
+		"light":-55,
+		"darkness":65,
+		"bio":30
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/kender.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/kender.json
@@ -1,0 +1,25 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":1,
+		"stab":1,
+		"explosion":5,
+		"magic":1,
+		"projectile":-25
+	},
+	
+	"defense_element":{
+		"water":1,
+		"wind":2,
+		"earth":-2,
+		"fire":1,
+		"ice":1,
+		"thunder":1,
+		"light":-15,
+		"darkness":-15
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/kenku.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/kenku.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"wind",
+	
+	"defense_stlye":{
+		"slash":15,
+		"stab":15,
+		"explosion":5,
+		"magic":-5,
+		"projectile":-15
+	},
+	
+	"defense_element":{
+		"water":15,
+		"wind":35,
+		"earth":-15,
+		"fire":-30,
+		"ice":10,
+		"thunder":20,
+		"light":20,
+		"darkness":-20,
+		"bio":-10
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/kobold.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/kobold.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"stab",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":-15,
+		"stab":-15,
+		"explosion":-15,
+		"magic":-25,
+		"projectile":25
+	},
+	
+	"defense_element":{
+		"water":15,
+		"wind":-25,
+		"earth":15,
+		"fire":20,
+		"ice":20,
+		"thunder":10,
+		"light":-50,
+		"darkness":75,
+		"bio":20
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/korred.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/korred.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"basic",
+	"attack_element":"earth",
+	
+	"defense_stlye":{
+		"slash":50,
+		"stab":50,
+		"explosion":50,
+		"magic":-25,
+		"projectile":50
+	},
+	
+	"defense_element":{
+		"water":1,
+		"wind":-25,
+		"earth":100,
+		"fire":15,
+		"ice":5,
+		"thunder":35,
+		"light":-30,
+		"darkness":-30,
+		"bio":-10
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/kou_toa.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/kou_toa.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"stab",
+	"attack_element":"water",
+	
+	"defense_stlye":{
+		"slash":5,
+		"stab":5,
+		"explosion":5,
+		"magic":5,
+		"projectile":1
+	},
+	
+	"defense_element":{
+		"water":65,
+		"wind":-15,
+		"earth":-25,
+		"fire":20,
+		"ice":-10,
+		"thunder":-40,
+		"light":-70,
+		"darkness":50,
+		"bio":30
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/lamia.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/lamia.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"stab",
+	"attack_element":"earth",
+	
+	"defense_stlye":{
+		"slash":25,
+		"stab":25,
+		"explosion":25,
+		"magic":20,
+		"projectile":15
+	},
+	
+	"defense_element":{
+		"water":-20,
+		"wind":-35,
+		"earth":45,
+		"fire":10,
+		"ice":10,
+		"thunder":10,
+		"light":-30,
+		"darkness":60,
+		"bio":20
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/leucrotta.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/leucrotta.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":25,
+		"stab":25,
+		"explosion":25,
+		"magic":5,
+		"projectile":20
+	},
+	
+	"defense_element":{
+		"water":1,
+		"wind":-35,
+		"earth":35,
+		"fire":10,
+		"ice":-10,
+		"thunder":10,
+		"light":-30,
+		"darkness":60,
+		"bio":20
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/lich.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/lich.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"magic",
+	"attack_element":"darkness",
+	
+	"defense_stlye":{
+		"slash":100,
+		"stab":100,
+		"explosion":100,
+		"magic":15,
+		"projectile":100
+	},
+	
+	"defense_element":{
+		"water":-15,
+		"wind":-15,
+		"earth":-15,
+		"fire":50,
+		"ice":100,
+		"thunder":100,
+		"light":-20,
+		"darkness":100,
+		"bio":-20
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/lizardfolk.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/lizardfolk.json
@@ -1,0 +1,25 @@
+{
+	"attack_style":"stab",
+	"attack_element":"bio",
+	
+	"defense_stlye":{
+		"slash":15,
+		"stab":35,
+		"explosion":-25,
+		"magic":-35,
+		"projectile":35
+	},
+	
+	"defense_element":{
+		"water":55,
+		"wind":55,
+		"earth":30,
+		"fire":15,
+		"ice":1,
+		"thunder":-15,
+		"light":15,
+		"darkness":-55
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/magmin.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/magmin.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"basic",
+	"attack_element":"fire",
+	
+	"defense_stlye":{
+		"slash":10,
+		"stab":10,
+		"explosion":10,
+		"magic":-5,
+		"projectile":25
+	},
+	
+	"defense_element":{
+		"water":-65,
+		"wind":35,
+		"earth":15,
+		"fire":100,
+		"ice":-30,
+		"thunder":20,
+		"light":-30,
+		"darkness":-30,
+		"bio":10
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/manticore.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/manticore.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"stab",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":35,
+		"stab":35,
+		"explosion":35,
+		"magic":-5,
+		"projectile":30
+	},
+	
+	"defense_element":{
+		"water":15,
+		"wind":-25,
+		"earth":30,
+		"fire":15,
+		"ice":30,
+		"thunder":50,
+		"light":-30,
+		"darkness":50,
+		"bio":15
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/meazel.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/meazel.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"darkness",
+	
+	"defense_stlye":{
+		"slash":-15,
+		"stab":-15,
+		"explosion":-15,
+		"magic":35,
+		"projectile":35
+	},
+	
+	"defense_element":{
+		"water":-15,
+		"wind":-15,
+		"earth":15,
+		"fire":10,
+		"ice":5,
+		"thunder":5,
+		"light":-25,
+		"darkness":50,
+		"bio":10
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/medusa.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/medusa.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"stab",
+	"attack_element":"bio",
+	
+	"defense_stlye":{
+		"slash":25,
+		"stab":25,
+		"explosion":25,
+		"magic":15,
+		"projectile":20
+	},
+	
+	"defense_element":{
+		"water":-25,
+		"wind":-45,
+		"earth":45,
+		"fire":-10,
+		"ice":10,
+		"thunder":10,
+		"light":-70,
+		"darkness":70,
+		"bio":50
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/meenlock.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/meenlock.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"light",
+	
+	"defense_stlye":{
+		"slash":10,
+		"stab":10,
+		"explosion":10,
+		"magic":5,
+		"projectile":25
+	},
+	
+	"defense_element":{
+		"water":65,
+		"wind":-15,
+		"earth":-15,
+		"fire":30,
+		"ice":10,
+		"thunder":-40,
+		"light":60,
+		"darkness":-30,
+		"bio":50
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/mephit.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/mephit.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"fire",
+	
+	"defense_stlye":{
+		"slash":2,
+		"stab":2,
+		"explosion":50,
+		"magic":-2,
+		"projectile":2
+	},
+	
+	"defense_element":{
+		"water":1,
+		"wind":1,
+		"earth":1,
+		"fire":50,
+		"ice":-50,
+		"thunder":1,
+		"light":-50,
+		"darkness":50,
+		"bio":50
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/merfolk.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/merfolk.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"stab",
+	"attack_element":"water",
+	
+	"defense_stlye":{
+		"slash":10,
+		"stab":10,
+		"explosion":10,
+		"magic":10,
+		"projectile":15
+	},
+	
+	"defense_element":{
+		"water":85,
+		"wind":25,
+		"earth":-15,
+		"fire":30,
+		"ice":-10,
+		"thunder":-50,
+		"light":10,
+		"darkness":10,
+		"bio":10
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/merrow.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/merrow.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"stab",
+	"attack_element":"water",
+	
+	"defense_stlye":{
+		"slash":25,
+		"stab":25,
+		"explosion":25,
+		"magic":-10,
+		"projectile":0
+	},
+	
+	"defense_element":{
+		"water":75,
+		"wind":25,
+		"earth":-15,
+		"fire":20,
+		"ice":-10,
+		"thunder":-50,
+		"light":20,
+		"darkness":20,
+		"bio":20
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/meteor.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/meteor.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"fire",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/mimic.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/mimic.json
@@ -1,0 +1,19 @@
+{
+	"attack_style":"basic",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":1,
+		"stab":1,
+		"explosion":10,
+		"magic":20,
+		"projectile":10
+	},
+	
+	"defense_element":{
+		"fire":-25,
+		"bio":50
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/mindwitness.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/mindwitness.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"magic",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":20,
+		"stab":20,
+		"explosion":20,
+		"magic":40,
+		"projectile":20
+	},
+	
+	"defense_element":{
+		"water":35,
+		"wind":25,
+		"earth":45,
+		"fire":-20,
+		"ice":-30,
+		"thunder":-40,
+		"light":-20,
+		"darkness":-20,
+		"bio":50
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/minotaur.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/minotaur.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":10,
+		"stab":10,
+		"explosion":15,
+		"magic":25,
+		"projectile":10
+	},
+	
+	"defense_element":{
+		"water":-25,
+		"wind":-35,
+		"earth":45,
+		"fire":20,
+		"ice":20,
+		"thunder":20,
+		"light":-40,
+		"darkness":80,
+		"bio":20
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/modron.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/modron.json
@@ -1,0 +1,25 @@
+{
+	"attack_style":"basic",
+	"attack_element":"light",
+	
+	"defense_stlye":{
+		"slash":25,
+		"stab":25,
+		"explosion":15,
+		"magic":-25,
+		"projectile":23
+	},
+	
+	"defense_element":{
+		"water":30,
+		"wind":30,
+		"earth":30,
+		"fire":-30,
+		"ice":-30,
+		"thunder":-30,
+		"light":50,
+		"darkness":-50
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/monkey.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/monkey.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":1,
+		"stab":1,
+		"explosion":1,
+		"magic":1,
+		"projectile":1
+	},
+	
+	"defense_element":{
+		"water":15,
+		"wind":15,
+		"earth":15,
+		"fire":-10,
+		"ice":10,
+		"thunder":-10,
+		"light":10,
+		"darkness":-10,
+		"bio":10
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/morkoth.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/morkoth.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"water",
+	
+	"defense_stlye":{
+		"slash":50,
+		"stab":50,
+		"explosion":50,
+		"magic":75,
+		"projectile":20
+	},
+	
+	"defense_element":{
+		"water":75,
+		"wind":-45,
+		"earth":-20,
+		"fire":10,
+		"ice":40,
+		"thunder":40,
+		"light":-30,
+		"darkness":40,
+		"bio":40
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/mummy.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/mummy.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"darkness",
+	
+	"defense_stlye":{
+		"slash":50,
+		"stab":50,
+		"explosion":55,
+		"magic":-20,
+		"projectile":50
+	},
+	
+	"defense_element":{
+		"water":-15,
+		"wind":15,
+		"earth":-25,
+		"fire":-60,
+		"ice":-10,
+		"thunder":-20,
+		"light":-80,
+		"darkness":110,
+		"bio":100
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/murloc.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/murloc.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"water",
+	
+	"defense_stlye":{
+		"slash":-5,
+		"stab":-5,
+		"explosion":5,
+		"magic":25,
+		"projectile":-15
+	},
+	
+	"defense_element":{
+		"water":80,
+		"wind":20,
+		"earth":20,
+		"fire":45,
+		"ice":-10,
+		"thunder":-40,
+		"light":25,
+		"darkness":-20,
+		"bio":30
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/myconid.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/myconid.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"bio",
+	
+	"defense_stlye":{
+		"slash":10,
+		"stab":10,
+		"explosion":10,
+		"magic":25,
+		"projectile":1
+	},
+	
+	"defense_element":{
+		"water":55,
+		"wind":35,
+		"earth":40,
+		"fire":-40,
+		"ice":40,
+		"thunder":20,
+		"light":-70,
+		"darkness":100,
+		"bio":75
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/naga.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/naga.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":-15,
+		"stab":-20,
+		"explosion":1,
+		"magic":5,
+		"projectile":-20
+	},
+	
+	"defense_element":{
+		"water":1,
+		"wind":1,
+		"earth":1,
+		"fire":1,
+		"ice":1,
+		"thunder":-20,
+		"light":10,
+		"darkness":10,
+		"bio":-10
+	},
+	
+	"biome_dependency":true
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/nagpa.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/nagpa.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":10,
+		"stab":10,
+		"explosion":10,
+		"magic":95,
+		"projectile":25
+	},
+	
+	"defense_element":{
+		"water":85,
+		"wind":50,
+		"earth":50,
+		"fire":10,
+		"ice":50,
+		"thunder":-70,
+		"light":-30,
+		"darkness":50,
+		"bio":85
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/neogi.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/neogi.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":-25,
+		"stab":-30,
+		"explosion":-25,
+		"magic":55,
+		"projectile":-30
+	},
+	
+	"defense_element":{
+		"water":25,
+		"wind":25,
+		"earth":35,
+		"fire":-25,
+		"ice":10,
+		"thunder":-30,
+		"light":50,
+		"darkness":50,
+		"bio":10
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/nightmare.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/nightmare.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":5,
+		"stab":5,
+		"explosion":5,
+		"magic":25,
+		"projectile":-5
+	},
+	
+	"defense_element":{
+		"water":-45,
+		"wind":25,
+		"earth":25,
+		"fire":100,
+		"ice":-25,
+		"thunder":25,
+		"light":-50,
+		"darkness":100,
+		"bio":10
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/nilbog.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/nilbog.json
@@ -1,0 +1,25 @@
+{
+	"attack_style":"basic",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":-15,
+		"stab":-15,
+		"explosion":-10,
+		"magic":-15,
+		"projectile":-25
+	},
+	
+	"defense_element":{
+		"water":-10,
+		"wind":10,
+		"earth":20,
+		"fire":1,
+		"ice":-20,
+		"thunder":-40,
+		"light":-50,
+		"darkness":70
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/nothic.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/nothic.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"darkness",
+	
+	"defense_stlye":{
+		"slash":25,
+		"stab":25,
+		"explosion":25,
+		"magic":15,
+		"projectile":25
+	},
+	
+	"defense_element":{
+		"water":45,
+		"wind":-5,
+		"earth":-5,
+		"fire":30,
+		"ice":10,
+		"thunder":-20,
+		"light":-20,
+		"darkness":40,
+		"bio":10
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/ochre_jelly_small.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/ochre_jelly_small.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"bio",
+	
+	"defense_stlye":{
+		"slash":100,
+		"stab":20,
+		"explosion":20,
+		"magic":-60,
+		"projectile":-20
+	},
+	
+	"defense_element":{
+		"water":20,
+		"wind":-20,
+		"earth":-20,
+		"fire":-20,
+		"ice":-20,
+		"thunder":100,
+		"light":10,
+		"darkness":10,
+		"bio":50
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/ochre_jelly_tiny.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/ochre_jelly_tiny.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"bio",
+	
+	"defense_stlye":{
+		"slash":100,
+		"stab":20,
+		"explosion":20,
+		"magic":-60,
+		"projectile":-20
+	},
+	
+	"defense_element":{
+		"water":20,
+		"wind":-20,
+		"earth":-20,
+		"fire":-20,
+		"ice":-20,
+		"thunder":100,
+		"light":10,
+		"darkness":10,
+		"bio":50
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/ochre_yellow.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/ochre_yellow.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"bio",
+	
+	"defense_stlye":{
+		"slash":100,
+		"stab":1,
+		"explosion":1,
+		"magic":-15,
+		"projectile":1
+	},
+	
+	"defense_element":{
+		"water":-25,
+		"wind":-25,
+		"earth":-25,
+		"fire":-25,
+		"ice":-25,
+		"thunder":100,
+		"light":1,
+		"darkness":1,
+		"bio":50
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/ogre.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/ogre.json
@@ -1,0 +1,19 @@
+{
+	"attack_style":"basic",
+	"attack_element":"earth",
+	
+	"defense_stlye":{
+		"slash":25,
+		"stab":10,
+		"explosion":-10,
+		"magic":-10,
+		"projectile":5
+	},
+	
+	"defense_element":{
+		"darkness":-10,
+		"light":-10
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/one_headed_hydra.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/one_headed_hydra.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"stab",
+	"attack_element":"water",
+	
+	"defense_stlye":{
+		"slash":50,
+		"stab":50,
+		"explosion":50,
+		"magic":-40,
+		"projectile":10
+	},
+	
+	"defense_element":{
+		"water":40,
+		"wind":20,
+		"earth":-20,
+		"fire":20,
+		"ice":20,
+		"thunder":-40,
+		"light":25,
+		"darkness":25,
+		"bio":20
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/oni.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/oni.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"magic",
+	"attack_element":"darkness",
+	
+	"defense_stlye":{
+		"slash":5,
+		"stab":-15,
+		"explosion":5,
+		"magic":1,
+		"projectile":-15
+	},
+	
+	"defense_element":{
+		"water":35,
+		"wind":35,
+		"earth":35,
+		"fire":40,
+		"ice":40,
+		"thunder":40,
+		"light":-70,
+		"darkness":110,
+		"bio":30
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/oni_human.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/oni_human.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":5,
+		"stab":5,
+		"explosion":5,
+		"magic":15,
+		"projectile":5
+	},
+	
+	"defense_element":{
+		"water":25,
+		"wind":25,
+		"earth":25,
+		"fire":30,
+		"ice":30,
+		"thunder":30,
+		"light":-40,
+		"darkness":55,
+		"bio":30
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/orc.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/orc.json
@@ -1,0 +1,19 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":50,
+		"stab":35,
+		"explosion":30,
+		"magic":-20,
+		"projectile":20
+	},
+	
+	"defense_element":{
+		"darkness":20,
+		"light":-20
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/orc_chief.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/orc_chief.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":40,
+		"stab":40,
+		"explosion":40,
+		"magic":10,
+		"projectile":10
+	},
+	
+	"defense_element":{
+		"water":5,
+		"wind":15,
+		"earth":15,
+		"fire":5,
+		"ice":20,
+		"thunder":20,
+		"light":-30,
+		"darkness":60,
+		"bio":20
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/otyugh.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/otyugh.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":45,
+		"stab":45,
+		"explosion":45,
+		"magic":-5,
+		"projectile":5
+	},
+	
+	"defense_element":{
+		"water":25,
+		"wind":-15,
+		"earth":35,
+		"fire":-30,
+		"ice":20,
+		"thunder":-10,
+		"light":-20,
+		"darkness":50,
+		"bio":50
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/owl.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/owl.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":1,
+		"stab":1,
+		"explosion":15,
+		"magic":25,
+		"projectile":1
+	},
+	
+	"defense_element":{
+		"water":-15,
+		"wind":55,
+		"earth":-15,
+		"fire":-50,
+		"ice":-50,
+		"thunder":50,
+		"light":-50,
+		"darkness":-50,
+		"bio":-10
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/owlbear.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/owlbear.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"stab",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":5,
+		"stab":5,
+		"explosion":5,
+		"magic":20,
+		"projectile":-5
+	},
+	
+	"defense_element":{
+		"water":-15,
+		"wind":35,
+		"earth":35,
+		"fire":10,
+		"ice":10,
+		"thunder":-20,
+		"light":-20,
+		"darkness":-20,
+		"bio":-30
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/panther.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/panther.json
@@ -1,0 +1,20 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+        "slash":1,
+        "stab":1,
+		"explosion":1,
+		"magic":-15,
+		"projectile":25
+	},
+	
+	"defense_element":{
+		"fire":-30,
+		"darkness":10,
+		"light":-10
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/pegasus.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/pegasus.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"light",
+	
+	"defense_stlye":{
+		"slash":15,
+		"stab":15,
+		"explosion":15,
+		"magic":15,
+		"projectile":15
+	},
+	
+	"defense_element":{
+		"water":15,
+		"wind":35,
+		"earth":15,
+		"fire":-15,
+		"ice":-10,
+		"thunder":-20,
+		"light":90,
+		"darkness":-60,
+		"bio":1
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/peryton.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/peryton.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"stab",
+	"attack_element":"wind",
+	
+	"defense_stlye":{
+		"slash":50,
+		"stab":50,
+		"explosion":50,
+		"magic":-25,
+		"projectile":10
+	},
+	
+	"defense_element":{
+		"water":5,
+		"wind":25,
+		"earth":15,
+		"fire":-5,
+		"ice":-5,
+		"thunder":-5,
+		"light":-30,
+		"darkness":60,
+		"bio":-20
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/phantom_fungus.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/phantom_fungus.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"magic",
+	"attack_element":"bio",
+	
+	"defense_stlye":{
+		"slash":1,
+		"stab":1,
+		"explosion":15,
+		"magic":25,
+		"projectile":1
+	},
+	
+	"defense_element":{
+		"water":15,
+		"wind":15,
+		"earth":15,
+		"fire":-20,
+		"ice":5,
+		"thunder":50,
+		"light":10,
+		"darkness":20,
+		"bio":50
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/phase_spider.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/phase_spider.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"stab",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":10,
+		"stab":10,
+		"explosion":10,
+		"magic":-20,
+		"projectile":25
+	},
+	
+	"defense_element":{
+		"water":10,
+		"wind":-25,
+		"earth":25,
+		"fire":10,
+		"ice":10,
+		"thunder":10,
+		"light":20,
+		"darkness":20,
+		"bio":50
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/phoenix.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/phoenix.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"fire",
+	
+	"defense_stlye":{
+		"slash":75,
+		"stab":75,
+		"explosion":75,
+		"magic":15,
+		"projectile":80
+	},
+	
+	"defense_element":{
+		"water":-40,
+		"wind":70,
+		"earth":-15,
+		"fire":100,
+		"ice":-25,
+		"thunder":50,
+		"light":60,
+		"darkness":50,
+		"bio":100
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/piercer.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/piercer.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"stab",
+	"attack_element":"water",
+	
+	"defense_stlye":{
+		"slash":25,
+		"stab":25,
+		"explosion":25,
+		"magic":-25,
+		"projectile":25
+	},
+	
+	"defense_element":{
+		"water":55,
+		"wind":-35,
+		"earth":-25,
+		"fire":20,
+		"ice":10,
+		"thunder":-40,
+		"light":-40,
+		"darkness":60,
+		"bio":10
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/pixie.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/pixie.json
@@ -1,0 +1,15 @@
+{
+	"attack_style":"magic",
+	"attack_element":"light",
+	
+	"defense_stlye":{
+		"magic":50
+	},
+	
+	"defense_element":{
+		"darkness":-30,
+		"light":30
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/pseudodragon.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/pseudodragon.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":15,
+		"stab":5,
+		"explosion":25,
+		"magic":45,
+		"projectile":20
+	},
+	
+	"defense_element":{
+		"water":15,
+		"wind":25,
+		"earth":-40,
+		"fire":10,
+		"ice":10,
+		"thunder":10,
+		"light":80,
+		"darkness":-50,
+		"bio":70
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/purple_worm.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/purple_worm.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"stab",
+	"attack_element":"earth",
+	
+	"defense_stlye":{
+		"slash":60,
+		"stab":60,
+		"explosion":60,
+		"magic":-55,
+		"projectile":-15
+	},
+	
+	"defense_element":{
+		"water":-25,
+		"wind":-45,
+		"earth":75,
+		"fire":20,
+		"ice":20,
+		"thunder":10,
+		"light":10,
+		"darkness":10,
+		"bio":40
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/quaggoth.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/quaggoth.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":30,
+		"stab":30,
+		"explosion":30,
+		"magic":-10,
+		"projectile":10
+	},
+	
+	"defense_element":{
+		"water":-20,
+		"wind":-20,
+		"earth":-20,
+		"fire":20,
+		"ice":20,
+		"thunder":20,
+		"light":50,
+		"darkness":50,
+		"bio":100
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/quickling.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/quickling.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"stab",
+	"attack_element":"light",
+	
+	"defense_stlye":{
+		"slash":-5,
+		"stab":-5,
+		"explosion":-5,
+		"magic":35,
+		"projectile":-15
+	},
+	
+	"defense_element":{
+		"water":-15,
+		"wind":-35,
+		"earth":-25,
+		"fire":30,
+		"ice":30,
+		"thunder":30,
+		"light":70,
+		"darkness":-20,
+		"bio":20
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/quipper.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/quipper.json
@@ -1,0 +1,25 @@
+{
+	"attack_style":"basic",
+	"attack_element":"water",
+	
+	"defense_stlye":{
+		"slash":1,
+		"stab":1,
+		"explosion":-25,
+		"magic":-5,
+		"projectile":5
+	},
+	
+	"defense_element":{
+		"water":100,
+		"wind":-15,
+		"earth":10,
+		"fire":10,
+		"ice":15,
+		"thunder":-80,
+		"light":-10,
+		"darkness":-10
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/rakshasa.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/rakshasa.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":100,
+		"stab":50,
+		"explosion":100,
+		"magic":50,
+		"projectile":100
+	},
+	
+	"defense_element":{
+		"water":-35,
+		"wind":-35,
+		"earth":-25,
+		"fire":50,
+		"ice":50,
+		"thunder":50,
+		"light":-50,
+		"darkness":75,
+		"bio":50
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/raptor.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/raptor.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":15,
+		"stab":15,
+		"explosion":15,
+		"magic":-20,
+		"projectile":20
+	},
+	
+	"defense_element":{
+		"water":15,
+		"wind":15,
+		"earth":15,
+		"fire":10,
+		"ice":10,
+		"thunder":10,
+		"light":10,
+		"darkness":10,
+		"bio":10
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/red_slaad.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/red_slaad.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"stab",
+	"attack_element":"bio",
+	
+	"defense_stlye":{
+		"slash":30,
+		"stab":30,
+		"explosion":30,
+		"magic":40,
+		"projectile":10
+	},
+	
+	"defense_element":{
+		"water":35,
+		"wind":-15,
+		"earth":15,
+		"fire":50,
+		"ice":50,
+		"thunder":50,
+		"light":25,
+		"darkness":25,
+		"bio":30
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/redcap.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/redcap.json
@@ -1,0 +1,25 @@
+{
+	"attack_style":"slash",
+	"attack_element":"light",
+	
+	"defense_stlye":{
+		"slash":25,
+		"stab":25,
+		"explosion":25,
+		"magic":-45,
+		"projectile":30
+	},
+	
+	"defense_element":{
+		"water":1,
+		"wind":1,
+		"earth":-25,
+		"fire":-25,
+		"ice":25,
+		"thunder":35,
+		"light":80,
+		"darkness":-80
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/remorhaze.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/remorhaze.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"stab",
+	"attack_element":"fire",
+	
+	"defense_stlye":{
+		"slash":55,
+		"stab":55,
+		"explosion":55,
+		"magic":-30,
+		"projectile":15
+	},
+	
+	"defense_element":{
+		"water":35,
+		"wind":25,
+		"earth":15,
+		"fire":100,
+		"ice":100,
+		"thunder":30,
+		"light":30,
+		"darkness":30,
+		"bio":-50
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/retriever.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/retriever.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":25,
+		"stab":25,
+		"explosion":25,
+		"magic":-30,
+		"projectile":30
+	},
+	
+	"defense_element":{
+		"water":25,
+		"wind":-25,
+		"earth":50,
+		"fire":-50,
+		"ice":25,
+		"thunder":-25,
+		"light":-30,
+		"darkness":100,
+		"bio":100
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/revenant.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/revenant.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"darkness",
+	
+	"defense_stlye":{
+		"slash":10,
+		"stab":10,
+		"explosion":15,
+		"magic":10,
+		"projectile":10
+	},
+	
+	"defense_element":{
+		"water":15,
+		"wind":15,
+		"earth":-15,
+		"fire":-10,
+		"ice":20,
+		"thunder":-20,
+		"light":-70,
+		"darkness":50,
+		"bio":100
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/roc.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/roc.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"wind",
+	
+	"defense_stlye":{
+		"slash":50,
+		"stab":50,
+		"explosion":50,
+		"magic":-35,
+		"projectile":0
+	},
+	
+	"defense_element":{
+		"water":15,
+		"wind":65,
+		"earth":-5,
+		"fire":-40,
+		"ice":65,
+		"thunder":10,
+		"light":10,
+		"darkness":10,
+		"bio":10
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/roper.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/roper.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":35,
+		"stab":35,
+		"explosion":35,
+		"magic":-55,
+		"projectile":35
+	},
+	
+	"defense_element":{
+		"water":-15,
+		"wind":-45,
+		"earth":45,
+		"fire":20,
+		"ice":20,
+		"thunder":20,
+		"light":-40,
+		"darkness":60,
+		"bio":10
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/rot_grub.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/rot_grub.json
@@ -1,0 +1,22 @@
+{
+	"attack_style":"slash",
+	"attack_element":"bio",
+	
+	"defense_stlye":{
+		"slash":-5,
+		"stab":-5,
+		"explosion":-25,
+		"magic":-5,
+		"projectile":-5
+	},
+	
+	"defense_element":{
+		"darkness":60,
+		"light":-60,
+		"bio":60,
+		"fire":-60,
+		"ice":-30
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/rust_monster.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/rust_monster.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"stab",
+	"attack_element":"bio",
+	
+	"defense_stlye":{
+		"slash":15,
+		"stab":5,
+		"explosion":-5,
+		"magic":-15,
+		"projectile":-5
+	},
+	
+	"defense_element":{
+		"water":20,
+		"wind":25,
+		"earth":25,
+		"fire":-15,
+		"ice":-20,
+		"thunder":-40,
+		"light":-10,
+		"darkness":-10,
+		"bio":30
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/sacred_statue.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/sacred_statue.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":60,
+		"stab":60,
+		"explosion":10,
+		"magic":20,
+		"projectile":-10
+	},
+	
+	"defense_element":{
+		"water":-25,
+		"wind":-10,
+		"earth":50,
+		"fire":50,
+		"ice":100,
+		"thunder":60,
+		"light":-20,
+		"darkness":100,
+		"bio":100
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/sahuagin.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/sahuagin.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"stab",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":10,
+		"stab":10,
+		"explosion":10,
+		"magic":25,
+		"projectile":5
+	},
+	
+	"defense_element":{
+		"water":65,
+		"wind":-15,
+		"earth":-25,
+		"fire":20,
+		"ice":-10,
+		"thunder":-30,
+		"light":-30,
+		"darkness":-50,
+		"bio":25
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/satyr.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/satyr.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":5,
+		"stab":5,
+		"explosion":15,
+		"magic":1,
+		"projectile":25
+	},
+	
+	"defense_element":{
+		"water":-5,
+		"wind":-25,
+		"earth":45,
+		"fire":1,
+		"ice":1,
+		"thunder":1,
+		"light":50,
+		"darkness":-50,
+		"bio":10
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/scarecrow.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/scarecrow.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"darkness",
+	
+	"defense_stlye":{
+		"slash":50,
+		"stab":50,
+		"explosion":50,
+		"magic":-5,
+		"projectile":50
+	},
+	
+	"defense_element":{
+		"water":-15,
+		"wind":35,
+		"earth":45,
+		"fire":-50,
+		"ice":-10,
+		"thunder":-30,
+		"light":-50,
+		"darkness":50,
+		"bio":100
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/scorpion.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/scorpion.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"stab",
+	"attack_element":"bio",
+	
+	"defense_stlye":{
+		"slash":-10,
+		"stab":-10,
+		"explosion":-15,
+		"magic":-55,
+		"projectile":5
+	},
+	
+	"defense_element":{
+		"water":-15,
+		"wind":15,
+		"earth":25,
+		"fire":10,
+		"ice":10,
+		"thunder":-10,
+		"light":20,
+		"darkness":20,
+		"bio":70
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/scum_creeper.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/scum_creeper.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"stab",
+	"attack_element":"bio",
+	
+	"defense_stlye":{
+		"slash":10,
+		"stab":0,
+		"explosion":0,
+		"magic":-45,
+		"projectile":0
+	},
+	
+	"defense_element":{
+		"water":5,
+		"wind":5,
+		"earth":5,
+		"fire":5,
+		"ice":5,
+		"thunder":5,
+		"light":-20,
+		"darkness":70,
+		"bio":50
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/seahorse.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/seahorse.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"basic",
+	"attack_element":"water",
+	
+	"defense_stlye":{
+		"slash":-15,
+		"stab":-15,
+		"explosion":25,
+		"magic":5,
+		"projectile":-25
+	},
+	
+	"defense_element":{
+		"water":80,
+		"wind":20,
+		"earth":-25,
+		"fire":5,
+		"ice":25,
+		"thunder":-25,
+		"light":25,
+		"darkness":-20,
+		"bio":50
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/seaspawn.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/seaspawn.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"water",
+	"attack_element":"explosion",
+	
+	"defense_stlye":{
+		"slash":-5,
+		"stab":-20,
+		"explosion":-30,
+		"magic":5,
+		"projectile":-20
+	},
+	
+	"defense_element":{
+		"water":75,
+		"wind":25,
+		"earth":-15,
+		"fire":30,
+		"ice":20,
+		"thunder":-60,
+		"light":-10,
+		"darkness":-10,
+		"bio":-30
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/shadow.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/shadow.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"darkness",
+	
+	"defense_stlye":{
+		"slash":1,
+		"stab":1,
+		"explosion":25,
+		"magic":-15,
+		"projectile":1
+	},
+	
+	"defense_element":{
+		"water":-25,
+		"wind":15,
+		"earth":-5,
+		"fire":50,
+		"ice":50,
+		"thunder":50,
+		"light":-80,
+		"darkness":100,
+		"bio":100
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/shambling_mound.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/shambling_mound.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":30,
+		"stab":30,
+		"explosion":30,
+		"magic":-25,
+		"projectile":-10
+	},
+	
+	"defense_element":{
+		"water":45,
+		"wind":5,
+		"earth":15,
+		"fire":-30,
+		"ice":-10,
+		"thunder":-10,
+		"light":20,
+		"darkness":20,
+		"bio":80
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/shark.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/shark.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"stab",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":1,
+		"stab":1,
+		"explosion":15,
+		"magic":25,
+		"projectile":1
+	},
+	
+	"defense_element":{
+		"water":75,
+		"wind":-15,
+		"earth":-25,
+		"fire":60,
+		"ice":-10,
+		"thunder":-60,
+		"light":10,
+		"darkness":10,
+		"bio":10
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/shrieker.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/shrieker.json
@@ -1,0 +1,20 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"wind",
+	
+	"defense_stlye":{
+		"slash":-15,
+		"stab":-15,
+		"explosion":-5,
+		"magic":10,
+		"projectile":-10
+	},
+	
+	"defense_element":{
+		"bio":100,
+		"fire":-40,
+		"light":-20
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/skeleton.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/skeleton.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"stab",
+	"attack_element":"darkness",
+	
+	"defense_stlye":{
+		"slash":5,
+		"stab":15,
+		"explosion":-25,
+		"magic":-10,
+		"projectile":15
+	},
+	
+	"defense_element":{
+		"water":5,
+		"wind":15,
+		"earth":15,
+		"fire":-10,
+		"ice":-20,
+		"thunder":-10,
+		"light":-70,
+		"darkness":80,
+		"bio":50
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/skin_changer.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/skin_changer.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":90,
+		"stab":90,
+		"explosion":90,
+		"magic":-30,
+		"projectile":90
+	},
+	
+	"defense_element":{
+		"water":15,
+		"wind":15,
+		"earth":15,
+		"fire":-10,
+		"ice":50,
+		"thunder":-30,
+		"light":-10,
+		"darkness":-10,
+		"bio":-40
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/slithering_tracker.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/slithering_tracker.json
@@ -1,0 +1,23 @@
+{
+	"attack_style":"basic",
+	"attack_element":"water",
+	
+	"defense_stlye":{
+		"slash":50,
+		"stab":50,
+		"explosion":25,
+		"magic":-5,
+		"projectile":50
+	},
+	
+	"defense_element":{
+		"water":70,
+		"wind":20,
+		"earth":-20,
+		"fire":-50,
+		"ice":-50,
+		"thunder":-50
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/small_black_pudding.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/small_black_pudding.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"bio",
+	
+	"defense_stlye":{
+		"slash":100,
+		"stab":1,
+		"explosion":1,
+		"magic":-25,
+		"projectile":1
+	},
+	
+	"defense_element":{
+		"water":25,
+		"wind":25,
+		"earth":25,
+		"fire":-50,
+		"ice":100,
+		"thunder":100,
+		"light":10,
+		"darkness":10,
+		"bio":100
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/snake.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/snake.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"bio",
+	
+	"defense_stlye":{
+		"slash":1,
+		"stab":1,
+		"explosion":15,
+		"magic":25,
+		"projectile":1
+	},
+	
+	"defense_element":{
+		"water":-15,
+		"wind":-15,
+		"earth":-15,
+		"fire":20,
+		"ice":-20,
+		"thunder":-20,
+		"light":-20,
+		"darkness":-40,
+		"bio":-20
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/sorrowsworn.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/sorrowsworn.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"stab",
+	"attack_element":"darkness",
+	
+	"defense_stlye":{
+		"slash":70,
+		"stab":70,
+		"explosion":70,
+		"magic":-15,
+		"projectile":10
+	},
+	
+	"defense_element":{
+		"water":-15,
+		"wind":45,
+		"earth":45,
+		"fire":-10,
+		"ice":10,
+		"thunder":20,
+		"light":-30,
+		"darkness":60,
+		"bio":-20
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/specter.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/specter.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"magic",
+	"attack_element":"darkness",
+	
+	"defense_stlye":{
+		"slash":50,
+		"stab":50,
+		"explosion":75,
+		"magic":-75,
+		"projectile":50
+	},
+	
+	"defense_element":{
+		"water":50,
+		"wind":50,
+		"earth":50,
+		"fire":50,
+		"ice":50,
+		"thunder":50,
+		"light":-70,
+		"darkness":100,
+		"bio":100
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/spriggan.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/spriggan.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"magic",
+	"attack_element":"bio",
+	
+	"defense_stlye":{
+		"slash":25,
+		"stab":25,
+		"explosion":15,
+		"magic":25,
+		"projectile":1
+	},
+	
+	"defense_element":{
+		"water":35,
+		"wind":-25,
+		"earth":15,
+		"fire":-40,
+		"ice":10,
+		"thunder":-10,
+		"light":30,
+		"darkness":10,
+		"bio":70
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/sprite.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/sprite.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"light",
+	
+	"defense_stlye":{
+		"slash":1,
+		"stab":1,
+		"explosion":1,
+		"magic":25,
+		"projectile":35
+	},
+	
+	"defense_element":{
+		"water":15,
+		"wind":15,
+		"earth":15,
+		"fire":-10,
+		"ice":-10,
+		"thunder":-10,
+		"light":60,
+		"darkness":-30,
+		"bio":-10
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/stirge.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/stirge.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"stab",
+	"attack_element":"darkness",
+	
+	"defense_stlye":{
+		"slash":5,
+		"stab":5,
+		"explosion":5,
+		"magic":-50,
+		"projectile":30
+	},
+	
+	"defense_element":{
+		"water":25,
+		"wind":45,
+		"earth":15,
+		"fire":10,
+		"ice":-20,
+		"thunder":20,
+		"light":-35,
+		"darkness":70,
+		"bio":20
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/thorny.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/thorny.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"stab",
+	"attack_element":"bio",
+	
+	"defense_stlye":{
+		"slash":15,
+		"stab":50,
+		"explosion":15,
+		"magic":-40,
+		"projectile":10
+	},
+	
+	"defense_element":{
+		"water":-25,
+		"wind":-25,
+		"earth":-25,
+		"fire":25,
+		"ice":25,
+		"thunder":50,
+		"light":10,
+		"darkness":10,
+		"bio":50
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/three_headed_hydra.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/three_headed_hydra.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"stab",
+	"attack_element":"water",
+	
+	"defense_stlye":{
+		"slash":50,
+		"stab":50,
+		"explosion":60,
+		"magic":-40,
+		"projectile":10
+	},
+	
+	"defense_element":{
+		"water":40,
+		"wind":20,
+		"earth":-20,
+		"fire":20,
+		"ice":20,
+		"thunder":-40,
+		"light":25,
+		"darkness":25,
+		"bio":20
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/tiefling.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/tiefling.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":5,
+		"stab":5,
+		"explosion":5,
+		"magic":15,
+		"projectile":0
+	},
+	
+	"defense_element":{
+		"water":-25,
+		"wind":-15,
+		"earth":5,
+		"fire":20,
+		"ice":-5,
+		"thunder":5,
+		"light":-30,
+		"darkness":15,
+		"bio":10
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/tiny_black_pudding.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/tiny_black_pudding.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"bio",
+	
+	"defense_stlye":{
+		"slash":100,
+		"stab":1,
+		"explosion":1,
+		"magic":-25,
+		"projectile":1
+	},
+	
+	"defense_element":{
+		"water":25,
+		"wind":25,
+		"earth":25,
+		"fire":-50,
+		"ice":100,
+		"thunder":100,
+		"light":10,
+		"darkness":10,
+		"bio":100
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/tlincalli.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/tlincalli.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"earth",
+	
+	"defense_stlye":{
+		"slash":30,
+		"stab":30,
+		"explosion":30,
+		"magic":0,
+		"projectile":15
+	},
+	
+	"defense_element":{
+		"water":-15,
+		"wind":-25,
+		"earth":50,
+		"fire":20,
+		"ice":-20,
+		"thunder":10,
+		"light":-20,
+		"darkness":50,
+		"bio":25
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/tortle.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/tortle.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"water",
+	
+	"defense_stlye":{
+		"slash":10,
+		"stab":10,
+		"explosion":10,
+		"magic":20,
+		"projectile":0
+	},
+	
+	"defense_element":{
+		"water":15,
+		"wind":-15,
+		"earth":-5,
+		"fire":10,
+		"ice":-10,
+		"thunder":-10,
+		"light":50,
+		"darkness":-30,
+		"bio":10
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/trogolodyte.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/trogolodyte.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"bio",
+	
+	"defense_stlye":{
+		"slash":20,
+		"stab":20,
+		"explosion":20,
+		"magic":-20,
+		"projectile":0
+	},
+	
+	"defense_element":{
+		"water":15,
+		"wind":5,
+		"earth":25,
+		"fire":-20,
+		"ice":20,
+		"thunder":20,
+		"light":-40,
+		"darkness":80,
+		"bio":20
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/twig_blight.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/twig_blight.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"bio",
+	
+	"defense_stlye":{
+		"slash":-5,
+		"stab":5,
+		"explosion":5,
+		"magic":-25,
+		"projectile":5
+	},
+	
+	"defense_element":{
+		"water":55,
+		"wind":25,
+		"earth":25,
+		"fire":-50,
+		"ice":10,
+		"thunder":-25,
+		"light":40,
+		"darkness":40,
+		"bio":100
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/two_headed_hill_troll.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/two_headed_hill_troll.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"bio",
+	
+	"defense_stlye":{
+		"slash":55,
+		"stab":55,
+		"explosion":55,
+		"magic":0,
+		"projectile":25
+	},
+	
+	"defense_element":{
+		"water":-10,
+		"wind":-35,
+		"earth":65,
+		"fire":30,
+		"ice":10,
+		"thunder":10,
+		"light":-45,
+		"darkness":90,
+		"bio":-300
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/two_headed_hydra.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/two_headed_hydra.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"stab",
+	"attack_element":"water",
+	
+	"defense_stlye":{
+		"slash":50,
+		"stab":50,
+		"explosion":60,
+		"magic":-40,
+		"projectile":10
+	},
+	
+	"defense_element":{
+		"water":40,
+		"wind":20,
+		"earth":-20,
+		"fire":20,
+		"ice":20,
+		"thunder":-40,
+		"light":25,
+		"darkness":25,
+		"bio":20
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/umber_hulk.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/umber_hulk.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":30,
+		"stab":30,
+		"explosion":5,
+		"magic":-5,
+		"projectile":15
+	},
+	
+	"defense_element":{
+		"water":-15,
+		"wind":-15,
+		"earth":35,
+		"fire":20,
+		"ice":-10,
+		"thunder":20,
+		"light":-35,
+		"darkness":70,
+		"bio":30
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/unicorn.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/unicorn.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"magic",
+	"attack_element":"light",
+	
+	"defense_stlye":{
+		"slash":-15,
+		"stab":-25,
+		"explosion":-15,
+		"magic":75,
+		"projectile":-25
+	},
+	
+	"defense_element":{
+		"water":-15,
+		"wind":-25,
+		"earth":-25,
+		"fire":30,
+		"ice":30,
+		"thunder":30,
+		"light":100,
+		"darkness":-70,
+		"bio":100
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/vampire.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/vampire.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"stab",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":50,
+		"stab":50,
+		"explosion":-10,
+		"magic":15,
+		"projectile":50
+	},
+	
+	"defense_element":{
+		"water":15,
+		"wind":35,
+		"earth":-25,
+		"fire":-40,
+		"ice":10,
+		"thunder":10,
+		"light":-60,
+		"darkness":80,
+		"bio":10
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/vargouille.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/vargouille.json
@@ -1,0 +1,24 @@
+{
+	"attack_style":"stab",
+	"attack_element":"bio",
+	
+	"defense_stlye":{
+		"slash":10,
+		"stab":15,
+		"explosion":25,
+		"magic":1,
+		"projectile":10
+	},
+	
+	"defense_element":{
+		"earth":-25,
+		"wind":-25,
+		"thunder":50,
+		"fire":50,
+		"ice":50,
+		"light":-25,
+		"bio":100
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/vegepygmy.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/vegepygmy.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"bio",
+	
+	"defense_stlye":{
+		"slash":15,
+		"stab":60,
+		"explosion":15,
+		"magic":-10,
+		"projectile":60
+	},
+	
+	"defense_element":{
+		"water":25,
+		"wind":-25,
+		"earth":-15,
+		"fire":-40,
+		"ice":-10,
+		"thunder":50,
+		"light":10,
+		"darkness":10,
+		"bio":50
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/violet_fungus.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/violet_fungus.json
@@ -1,0 +1,19 @@
+{
+	"attack_style":"basic",
+	"attack_element":"darkness",
+	
+	"defense_stlye":{
+		"slash":1,
+		"stab":1,
+		"explosion":1,
+		"magic":-5,
+		"projectile":1
+	},
+	
+	"defense_element":{
+		"darkness":50,
+		"light":-50
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/vulture.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/vulture.json
@@ -1,0 +1,23 @@
+{
+	"attack_style":"stab",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":-5,
+		"stab":-5,
+		"explosion":-20,
+		"magic":-4,
+		"projectile":-25
+	},
+	
+	"defense_element":{
+		"water":-40,
+		"wind":80,
+		"earth":-20,
+		"fire":-30,
+		"ice":-30,
+		"thunder":-20
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/water_weird.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/water_weird.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"water",
+	
+	"defense_stlye":{
+		"slash":10,
+		"stab":10,
+		"explosion":75,
+		"magic":-5,
+		"projectile":25
+	},
+	
+	"defense_element":{
+		"water":75,
+		"wind":-75,
+		"earth":-55,
+		"fire":50,
+		"ice":50,
+		"thunder":35,
+		"light":-10,
+		"darkness":-10,
+		"bio":100
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/wendigo.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/wendigo.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"darkness",
+	
+	"defense_stlye":{
+		"slash":20,
+		"stab":20,
+		"explosion":20,
+		"magic":5,
+		"projectile":35
+	},
+	
+	"defense_element":{
+		"water":15,
+		"wind":15,
+		"earth":15,
+		"fire":-50,
+		"ice":100,
+		"thunder":-20,
+		"light":-35,
+		"darkness":75,
+		"bio":100
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/werewolfday.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/werewolfday.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":1,
+		"stab":1,
+		"explosion":1,
+		"magic":-5,
+		"projectile":1
+	},
+	
+	"defense_element":{
+		"water":-15,
+		"wind":-15,
+		"earth":-15,
+		"fire":-10,
+		"ice":-10,
+		"thunder":-10,
+		"light":-60,
+		"darkness":80,
+		"bio":-10
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/werewolfnight.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/werewolfnight.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":35,
+		"stab":35,
+		"explosion":35,
+		"magic":-35,
+		"projectile":35
+	},
+	
+	"defense_element":{
+		"water":25,
+		"wind":25,
+		"earth":25,
+		"fire":30,
+		"ice":30,
+		"thunder":30,
+		"light":-60,
+		"darkness":80,
+		"bio":30
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/wight.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/wight.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"darkness",
+	
+	"defense_stlye":{
+		"slash":50,
+		"stab":50,
+		"explosion":50,
+		"magic":15,
+		"projectile":50
+	},
+	
+	"defense_element":{
+		"water":-25,
+		"wind":15,
+		"earth":-5,
+		"fire":-30,
+		"ice":40,
+		"thunder":-20,
+		"light":-80,
+		"darkness":100,
+		"bio":100
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/will_o_wisp.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/will_o_wisp.json
@@ -1,0 +1,23 @@
+{
+	"attack_style":"magic",
+	"attack_element":"thunder",
+	
+	"defense_stlye":{
+		"slash":50,
+		"stab":50,
+		"explosion":30,
+		"magic":20,
+		"projectile":50
+	},
+	
+	"defense_element":{
+		"fire":50,
+		"bio":100,
+		"ice":50,
+		"darkness":50,
+		"thunder":100,
+		"light":-50
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/winter_wolf.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/winter_wolf.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"ice",
+	
+	"defense_stlye":{
+		"slash":15,
+		"stab":-5,
+		"explosion":5,
+		"magic":10,
+		"projectile":1
+	},
+	
+	"defense_element":{
+		"water":35,
+		"wind":35,
+		"earth":25,
+		"fire":-40,
+		"ice":70,
+		"thunder":-20,
+		"light":-10,
+		"darkness":-10,
+		"bio":-20
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/wizard.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/wizard.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"magic",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":-10,
+		"stab":-10,
+		"explosion":-10,
+		"magic":55,
+		"projectile":10
+	},
+	
+	"defense_element":{
+		"water":25,
+		"wind":25,
+		"earth":25,
+		"fire":25,
+		"ice":25,
+		"thunder":25,
+		"light":20,
+		"darkness":-20,
+		"bio":-40
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/wood_woad.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/wood_woad.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":1,
+		"stab":50,
+		"explosion":50,
+		"magic":25,
+		"projectile":50
+	},
+	
+	"defense_element":{
+		"water":110,
+		"wind":25,
+		"earth":25,
+		"fire":-50,
+		"ice":20,
+		"thunder":50,
+		"light":110,
+		"darkness":-50,
+		"bio":110
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/worg.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/worg.json
@@ -1,0 +1,20 @@
+{
+	"attack_style":"stab",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+        "slash":2,
+        "stab":1,
+		"explosion":1,
+		"magic":-1,
+		"projectile":1
+	},
+	
+	"defense_element":{
+		"fire":20,
+		"darkness":-20,
+		"light":-20
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/wraith.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/wraith.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"darkness",
+	
+	"defense_stlye":{
+		"slash":50,
+		"stab":50,
+		"explosion":70,
+		"magic":15,
+		"projectile":50
+	},
+	
+	"defense_element":{
+		"water":-35,
+		"wind":15,
+		"earth":35,
+		"fire":50,
+		"ice":50,
+		"thunder":60,
+		"light":-70,
+		"darkness":100,
+		"bio":100
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/wyvern.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/wyvern.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"earth",
+	
+	"defense_stlye":{
+		"slash":30,
+		"stab":30,
+		"explosion":30,
+		"magic":-15,
+		"projectile":0
+	},
+	
+	"defense_element":{
+		"water":-15,
+		"wind":-5,
+		"earth":65,
+		"fire":-30,
+		"ice":-20,
+		"thunder":-40,
+		"light":20,
+		"darkness":20,
+		"bio":20
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/xorn.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/xorn.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"earth",
+	
+	"defense_stlye":{
+		"slash":60,
+		"stab":60,
+		"explosion":60,
+		"magic":5,
+		"projectile":0
+	},
+	
+	"defense_element":{
+		"water":25,
+		"wind":-15,
+		"earth":75,
+		"fire":20,
+		"ice":10,
+		"thunder":10,
+		"light":-40,
+		"darkness":40,
+		"bio":15
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/xvart.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/xvart.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"stab",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":5,
+		"stab":5,
+		"explosion":5,
+		"magic":-15,
+		"projectile":5
+	},
+	
+	"defense_element":{
+		"water":25,
+		"wind":15,
+		"earth":25,
+		"fire":-10,
+		"ice":40,
+		"thunder":10,
+		"light":-30,
+		"darkness":50,
+		"bio":10
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/yeth_hound.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/yeth_hound.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"stab",
+	"attack_element":"light",
+	
+	"defense_stlye":{
+		"slash":45,
+		"stab":35,
+		"explosion":45,
+		"magic":15,
+		"projectile":-5
+	},
+	
+	"defense_element":{
+		"water":15,
+		"wind":15,
+		"earth":15,
+		"fire":-20,
+		"ice":-20,
+		"thunder":-20,
+		"light":100,
+		"darkness":100,
+		"bio":20
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/yeti.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/yeti.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"ice",
+	
+	"defense_stlye":{
+		"slash":25,
+		"stab":25,
+		"explosion":25,
+		"magic":5,
+		"projectile":10
+	},
+	
+	"defense_element":{
+		"water":55,
+		"wind":35,
+		"earth":-15,
+		"fire":-60,
+		"ice":100,
+		"thunder":30,
+		"light":-40,
+		"darkness":50,
+		"bio":-20
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/yuan_ti.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/yuan_ti.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"slash",
+	"attack_element":"bio",
+	
+	"defense_stlye":{
+		"slash":5,
+		"stab":5,
+		"explosion":5,
+		"magic":85,
+		"projectile":10
+	},
+	
+	"defense_element":{
+		"water":35,
+		"wind":25,
+		"earth":-25,
+		"fire":-40,
+		"ice":-30,
+		"thunder":-20,
+		"light":-20,
+		"darkness":30,
+		"bio":100
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/entities/zombie.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/entities/zombie.json
@@ -1,0 +1,26 @@
+{
+	"attack_style":"stab",
+	"attack_element":"natural",
+	
+	"defense_stlye":{
+		"slash":-5,
+		"stab":-5,
+		"explosion":-15,
+		"magic":5,
+		"projectile":-5
+	},
+	
+	"defense_element":{
+		"water":-15,
+		"wind":-15,
+		"earth":25,
+		"fire":-20,
+		"ice":-10,
+		"thunder":-20,
+		"light":-60,
+		"darkness":110,
+		"bio":30
+	},
+	
+	"biome_dependency":false
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/acid_attack.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/acid_attack.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"bio",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/amber_armor_boots.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/amber_armor_boots.json
@@ -1,0 +1,14 @@
+{
+	"defense_style":{
+		"slash":5,
+		"stab":5,
+		"magic":5,
+		"explosion":14
+	},
+	
+	"defense_element":{
+		"wind":10,
+		"earth":10,
+		"bio":-10
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/amber_armor_chestplate.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/amber_armor_chestplate.json
@@ -1,0 +1,14 @@
+{
+	"defense_style":{
+		"slash":6,
+		"stab":2,
+		"projectile":12,
+		"explosion":17
+	},
+	
+	"defense_element":{
+		"wind":10,
+		"earth":10,
+		"bio":-10
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/amber_armor_helmet.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/amber_armor_helmet.json
@@ -1,0 +1,14 @@
+{
+	"defense_style":{
+		"slash":6,
+		"stab":4,
+		"magic":5,
+		"explosion":10
+	},
+	
+	"defense_element":{
+		"fire":10,
+		"ice":10,
+		"bio":-10
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/amber_armor_leggings.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/amber_armor_leggings.json
@@ -1,0 +1,14 @@
+{
+	"defense_style":{
+		"slash":6,
+		"stab":5,
+		"projectile":13,
+		"explosion":11
+	},
+	
+	"defense_element":{
+		"wind":10,
+		"thunder":10,
+		"bio":-10
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/amber_axe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/amber_axe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"wind",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/amber_battleaxe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/amber_battleaxe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"wind",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/amber_dagger.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/amber_dagger.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"stab",
+	"attack_element":"wind",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/amber_greatsword.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/amber_greatsword.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"wind",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/amber_halberd.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/amber_halberd.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"wind",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/amber_hand_axe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/amber_hand_axe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"wind",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/amber_longsword.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/amber_longsword.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"wind",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/amber_mace.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/amber_mace.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"wind",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/amber_scimitar.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/amber_scimitar.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"wind",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/amber_sickle.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/amber_sickle.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"wind",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/amber_spear.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/amber_spear.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"stab",
+	"attack_element":"wind",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/amber_sword.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/amber_sword.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"wind",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/amber_warhammer.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/amber_warhammer.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"wind",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/amethyst_axe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/amethyst_axe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/amethyst_battleaxe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/amethyst_battleaxe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/amethyst_dagger.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/amethyst_dagger.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/amethyst_greatsword.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/amethyst_greatsword.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/amethyst_halberd.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/amethyst_halberd.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/amethyst_hand_axe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/amethyst_hand_axe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/amethyst_longsword.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/amethyst_longsword.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/amethyst_mace.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/amethyst_mace.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/amethyst_scimitar.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/amethyst_scimitar.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/amethyst_sickle.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/amethyst_sickle.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/amethyst_spear.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/amethyst_spear.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/amethyst_sword.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/amethyst_sword.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/amethyst_warhammer.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/amethyst_warhammer.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/aquamarine_armor_boots.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/aquamarine_armor_boots.json
@@ -1,0 +1,14 @@
+{
+	"defense_style":{
+		"slash":5,
+		"projectile":6,
+		"magic":4,
+		"explosion":2
+	},
+	
+	"defense_element":{
+		"water":10,
+		"ice":10,
+		"thunder":-10
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/aquamarine_armor_chestplate.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/aquamarine_armor_chestplate.json
@@ -1,0 +1,14 @@
+{
+	"defense_style":{
+		"stab":8,
+		"projectile":7,
+		"magic":4,
+		"explosion":2
+	},
+	
+	"defense_element":{
+		"water":10,
+		"ice":10,
+		"thunder":-10
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/aquamarine_armor_helmet.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/aquamarine_armor_helmet.json
@@ -1,0 +1,14 @@
+{
+	"defense_style":{
+		"slash":6,
+		"projectile":5,
+		"magic":2,
+		"explosion":3
+	},
+	
+	"defense_element":{
+		"water":10,
+		"ice":10,
+		"thunder":-10
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/aquamarine_armor_leggings.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/aquamarine_armor_leggings.json
@@ -1,0 +1,14 @@
+{
+	"defense_style":{
+		"stab":6,
+		"projectile":4,
+		"magic":5,
+		"explosion":2
+	},
+	
+	"defense_element":{
+		"water":10,
+		"wind":10,
+		"thunder":-10
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/aquamarine_axe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/aquamarine_axe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"water",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/aquamarine_battleaxe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/aquamarine_battleaxe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"water",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/aquamarine_dagger.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/aquamarine_dagger.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"stab",
+	"attack_element":"water",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/aquamarine_greatsword.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/aquamarine_greatsword.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"water",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/aquamarine_halberd.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/aquamarine_halberd.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"water",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/aquamarine_hand_axe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/aquamarine_hand_axe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"water",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/aquamarine_longsword.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/aquamarine_longsword.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"water",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/aquamarine_mace.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/aquamarine_mace.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"water",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/aquamarine_scimitar.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/aquamarine_scimitar.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"water",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/aquamarine_sickle.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/aquamarine_sickle.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"water",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/aquamarine_spear.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/aquamarine_spear.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"stab",
+	"attack_element":"water",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/aquamarine_sword.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/aquamarine_sword.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"water",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/aquamarine_warhammer.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/aquamarine_warhammer.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"water",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/copper_armor_boots.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/copper_armor_boots.json
@@ -1,0 +1,13 @@
+{
+	"defense_style":{
+		"slash":8,
+		"stab":8,
+		"magic":-5,
+		"explosion":5
+	},
+	
+	"defense_element":{
+		"wind":2,
+		"earth":2
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/copper_armor_chestplate.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/copper_armor_chestplate.json
@@ -1,0 +1,13 @@
+{
+	"defense_style":{
+		"slash":12,
+		"stab":12,
+		"magic":-10,
+		"explosion":7
+	},
+	
+	"defense_element":{
+		"wind":2,
+		"earth":2
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/copper_armor_helmet.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/copper_armor_helmet.json
@@ -1,0 +1,13 @@
+{
+	"defense_style":{
+		"slash":8,
+		"stab":5,
+		"magic":-5,
+		"explosion":8
+	},
+	
+	"defense_element":{
+		"wind":2,
+		"earth":2
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/copper_armor_leggings.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/copper_armor_leggings.json
@@ -1,0 +1,11 @@
+{
+	"defense_style":{
+		"slash":12,
+		"stab":12,
+		"magic":-10,
+		"explosion":9
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/copper_battleaxe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/copper_battleaxe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/copper_dagger.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/copper_dagger.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"stab",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/copper_greatsword.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/copper_greatsword.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/copper_halberd.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/copper_halberd.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/copper_hand_axe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/copper_hand_axe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/copper_longsword.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/copper_longsword.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/copper_mace.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/copper_mace.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/copper_scimitar.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/copper_scimitar.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/copper_sickle.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/copper_sickle.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/copper_spear.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/copper_spear.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"stab",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/copper_warhammer.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/copper_warhammer.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/daggerof_venom.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/daggerof_venom.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"stab",
+	"attack_element":"bio",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/diamond_axe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/diamond_axe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/diamond_battleaxe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/diamond_battleaxe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/diamond_dagger.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/diamond_dagger.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"stab",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/diamond_greatsword.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/diamond_greatsword.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/diamond_halberd.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/diamond_halberd.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/diamond_hand_axe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/diamond_hand_axe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/diamond_longsword.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/diamond_longsword.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/diamond_mace.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/diamond_mace.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/diamond_scimitar.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/diamond_scimitar.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/diamond_sickle.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/diamond_sickle.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/diamond_spear.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/diamond_spear.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"stab",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/diamond_sword.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/diamond_sword.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/diamond_warhammer.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/diamond_warhammer.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/dragon_slayer.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/dragon_slayer.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"bio",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/dwarven_thrower.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/dwarven_thrower.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"earth",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/emerald_axe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/emerald_axe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"light",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/emerald_battleaxe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/emerald_battleaxe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"light",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/emerald_boots.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/emerald_boots.json
@@ -1,0 +1,15 @@
+{
+	"defense_style":{
+		"slash":5,
+		"stab":10,
+		"projectile":10,
+		"magic":15
+	},
+	
+	"defense_element":{
+		"fire":-20,
+		"water":10,
+		"thunder":-10,
+		"bio":20
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/emerald_chestplate.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/emerald_chestplate.json
@@ -1,0 +1,15 @@
+{
+	"defense_style":{
+		"slash":10,
+		"stab":15,
+		"magic":20,
+		"explosion":15
+	},
+	
+	"defense_element":{
+		"fire":-20,
+		"ice":10,
+		"earth":-10,
+		"bio":20
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/emerald_dagger.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/emerald_dagger.json
@@ -1,0 +1,11 @@
+{
+	"attack_style":"stab",
+	"attack_element":"light
+	",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/emerald_greatsword.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/emerald_greatsword.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"light",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/emerald_halberd.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/emerald_halberd.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"light",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/emerald_hand_axe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/emerald_hand_axe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"light",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/emerald_helmet.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/emerald_helmet.json
@@ -1,0 +1,15 @@
+{
+	"defense_style":{
+		"slash":5,
+		"stab":10,
+		"projectile":10,
+		"magic":15
+	},
+	
+	"defense_element":{
+		"fire":-20,
+		"water":10,
+		"thunder":-10,
+		"bio":20
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/emerald_leggings.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/emerald_leggings.json
@@ -1,0 +1,15 @@
+{
+	"defense_style":{
+		"slash":10,
+		"stab":15,
+		"magic":20,
+		"explosion":15
+	},
+	
+	"defense_element":{
+		"fire":-20,
+		"ice":10,
+		"earth":-10,
+		"bio":20
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/emerald_longsword.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/emerald_longsword.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"light",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/emerald_mace.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/emerald_mace.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"light",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/emerald_scimitar.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/emerald_scimitar.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"light",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/emerald_sickle.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/emerald_sickle.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"light",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/emerald_spear.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/emerald_spear.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"stab",
+	"attack_element":"light",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/emerald_sword.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/emerald_sword.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"light",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/emerald_warhammer.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/emerald_warhammer.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"light",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/feather_fall_spell.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/feather_fall_spell.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/firebal_spell.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/firebal_spell.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"fire",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/frost_brand.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/frost_brand.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"ice",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/gold_battleaxe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/gold_battleaxe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/gold_dagger.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/gold_dagger.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/gold_greatsword.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/gold_greatsword.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/gold_halberd.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/gold_halberd.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/gold_hand_axe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/gold_hand_axe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/gold_longsword.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/gold_longsword.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/gold_mace.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/gold_mace.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/gold_scimitar.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/gold_scimitar.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/gold_sickle.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/gold_sickle.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/gold_spear.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/gold_spear.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"stab",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/gold_sword.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/gold_sword.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/gold_warhammer.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/gold_warhammer.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/greater_fireball_spell.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/greater_fireball_spell.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"fire",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/holy_avenger.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/holy_avenger.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"light",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/iron_battleaxe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/iron_battleaxe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/iron_dagger.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/iron_dagger.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"stab",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/iron_greatsword.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/iron_greatsword.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/iron_halberd.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/iron_halberd.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/iron_hand_axe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/iron_hand_axe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/iron_javelin.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/iron_javelin.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"stab",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/iron_longsword.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/iron_longsword.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/iron_mace.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/iron_mace.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/iron_scimitar.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/iron_scimitar.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/iron_spear.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/iron_spear.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"stab",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/iron_warhammer.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/iron_warhammer.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/jade_armor_boots.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/jade_armor_boots.json
@@ -1,0 +1,13 @@
+{
+	"defense_style":{
+		"slash":3,
+		"stab":4,
+		"projectile":10
+	},
+	
+	"defense_element":{
+		"bio":10,
+		"water":10,
+		"fire":-10
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/jade_armor_chestplate.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/jade_armor_chestplate.json
@@ -1,0 +1,14 @@
+{
+	"defense_style":{
+		"slash":5,
+		"stab":5,
+		"projectile":5,
+		"magic":5
+	},
+	
+	"defense_element":{
+		"bio":10,
+		"water":10,
+		"fire":-10
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/jade_armor_helmet.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/jade_armor_helmet.json
@@ -1,0 +1,13 @@
+{
+	"defense_style":{
+		"slash":4,
+		"stab":6,
+		"projectile":5
+	},
+	
+	"defense_element":{
+		"bio":10,
+		"water":10,
+		"fire":-10
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/jade_armor_leggings.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/jade_armor_leggings.json
@@ -1,0 +1,12 @@
+{
+	"defense_style":{
+		"projectile":10,
+		"explosive":10
+	},
+	
+	"defense_element":{
+		"bio":10,
+		"darkness":10,
+		"fire":-10
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/jade_axe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/jade_axe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"bio",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/jade_battleaxe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/jade_battleaxe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"bio",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/jade_dagger.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/jade_dagger.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"stab",
+	"attack_element":"bio",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/jade_greatsword.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/jade_greatsword.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"bio",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/jade_halberd.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/jade_halberd.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"bio",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/jade_hand_axe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/jade_hand_axe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"bio",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/jade_longsword.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/jade_longsword.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"bio",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/jade_mace.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/jade_mace.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"bio",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/jade_scimitar.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/jade_scimitar.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"bio",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/jade_sickle.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/jade_sickle.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"bio",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/jade_spear.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/jade_spear.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"stab",
+	"attack_element":"bio",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/jade_sword.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/jade_sword.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"bio",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/jade_warhammer.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/jade_warhammer.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"bio",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/lead_armor_boots.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/lead_armor_boots.json
@@ -1,0 +1,12 @@
+{
+	"defense_style":{
+		"slash":8,
+		"stab":8,
+		"explosion":5,
+		"projectile":5
+	},
+	
+	"defense_element":{
+		"fire":3
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/lead_armor_chestplate.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/lead_armor_chestplate.json
@@ -1,0 +1,12 @@
+{
+	"defense_style":{
+		"slash":4,
+		"stab":4,
+		"explosion":7,
+		"projectile":7
+	},
+	
+	"defense_element":{
+		"fire":10
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/lead_armor_helmet.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/lead_armor_helmet.json
@@ -1,0 +1,12 @@
+{
+	"defense_style":{
+		"slash":7,
+		"stab":7,
+		"explosion":8,
+		"projectile":3
+	},
+	
+	"defense_element":{
+		"fire":12
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/lead_armor_leggings.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/lead_armor_leggings.json
@@ -1,0 +1,12 @@
+{
+	"defense_style":{
+		"slash":8,
+		"stab":8,
+		"explosion":5,
+		"projectile":5
+	},
+	
+	"defense_element":{
+		"fire":6
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/lead_axe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/lead_axe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/lead_battleaxe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/lead_battleaxe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/lead_dagger.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/lead_dagger.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"stab",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/lead_greatsword.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/lead_greatsword.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/lead_halberd.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/lead_halberd.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/lead_hand_axe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/lead_hand_axe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/lead_longsword.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/lead_longsword.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/lead_mace.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/lead_mace.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/lead_scimitar.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/lead_scimitar.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/lead_sickle.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/lead_sickle.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/lead_spear.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/lead_spear.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"stab",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/lead_sword.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/lead_sword.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/lead_warhammer.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/lead_warhammer.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/luck_blade.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/luck_blade.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/mithril_chestplate_chestplate.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/mithril_chestplate_chestplate.json
@@ -1,0 +1,14 @@
+{
+	"defense_style":{
+		"slash":15,
+		"stab":10,
+		"magic":15,
+		"projectile":10
+	},
+	
+	"defense_element":{
+		"darkness":30,
+		"light":20,
+		"fire":-20
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/nickel_armor_boots.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/nickel_armor_boots.json
@@ -1,0 +1,12 @@
+{
+	"defense_style":{
+		"slash":3,
+		"stab":3,
+		"magic":5,
+		"projectile":5
+	},
+	
+	"defense_element":{
+		"fire":10
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/nickel_armor_chestplate.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/nickel_armor_chestplate.json
@@ -1,0 +1,12 @@
+{
+	"defense_style":{
+		"slash":4,
+		"stab":5,
+		"magic":10,
+		"projectile":5
+	},
+	
+	"defense_element":{
+		"thunder":10
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/nickel_armor_helmet.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/nickel_armor_helmet.json
@@ -1,0 +1,12 @@
+{
+	"defense_style":{
+		"slash":3,
+		"stab":2,
+		"magic":8,
+		"projectile":5
+	},
+	
+	"defense_element":{
+		"ice":10
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/nickel_armor_leggings.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/nickel_armor_leggings.json
@@ -1,0 +1,12 @@
+{
+	"defense_style":{
+		"slash":5,
+		"stab":4,
+		"magic":7,
+		"projectile":10
+	},
+	
+	"defense_element":{
+		"light":10
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/nickel_axe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/nickel_axe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/nickel_battleaxe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/nickel_battleaxe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/nickel_dagger.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/nickel_dagger.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"stab",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/nickel_greatsword.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/nickel_greatsword.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/nickel_halberd.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/nickel_halberd.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/nickel_hand_axe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/nickel_hand_axe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/nickel_longsword.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/nickel_longsword.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/nickel_mace.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/nickel_mace.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/nickel_scimitar.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/nickel_scimitar.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/nickel_sickle.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/nickel_sickle.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/nickel_spear.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/nickel_spear.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"stab",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/nickel_sword.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/nickel_sword.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/nickel_warhammer.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/nickel_warhammer.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/nine_lives_stealer.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/nine_lives_stealer.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"magic",
+	"attack_element":"darkness",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/oathbow.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/oathbow.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"projectile",
+	"attack_element":"light",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/onyx_armor_boots.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/onyx_armor_boots.json
@@ -1,0 +1,14 @@
+{
+	"defense_style":{
+		"slash":5,
+		"stab":5,
+		"projectile":3,
+		"explosion":2
+	},
+	
+	"defense_element":{
+		"darkness":10,
+		"fire":10,
+		"light":-10
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/onyx_armor_chestplate.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/onyx_armor_chestplate.json
@@ -1,0 +1,14 @@
+{
+	"defense_style":{
+		"stab":6,
+		"projectile":6,
+		"magic":4,
+		"explosion":4
+	},
+	
+	"defense_element":{
+		"darkness":10,
+		"ice":10,
+		"light":-10
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/onyx_armor_helmet.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/onyx_armor_helmet.json
@@ -1,0 +1,14 @@
+{
+	"defense_style":{
+		"slash":6,
+		"stab":3,
+		"projectile":3,
+		"explosion":6
+	},
+	
+	"defense_element":{
+		"darkness":10,
+		"thunder":10,
+		"light":-10
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/onyx_armor_leggings.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/onyx_armor_leggings.json
@@ -1,0 +1,14 @@
+{
+	"defense_style":{
+		"stab":5,
+		"magic":10
+	},
+	
+	"defense_element":{
+		"darkness":5,
+		"ice":5,
+		"light":-10,
+		"fire":5,
+		"thunder":5
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/onyx_axe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/onyx_axe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/onyx_battleaxe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/onyx_battleaxe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"darkness",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/onyx_dagger.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/onyx_dagger.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"stab",
+	"attack_element":"darkness",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/onyx_greatsword.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/onyx_greatsword.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"darkness",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/onyx_halberd.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/onyx_halberd.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"darkness",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/onyx_hand_axe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/onyx_hand_axe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"darkness",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/onyx_longsword.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/onyx_longsword.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"darkness",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/onyx_mace.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/onyx_mace.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"darkness",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/onyx_scimitar.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/onyx_scimitar.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"darkness",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/onyx_sickle.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/onyx_sickle.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"darkness",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/onyx_spear.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/onyx_spear.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"stab",
+	"attack_element":"darkness",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/onyx_sword.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/onyx_sword.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"darkness",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/onyx_warhammer.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/onyx_warhammer.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"darkness",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/peridot_axe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/peridot_axe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/peridot_battleaxe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/peridot_battleaxe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/peridot_dagger.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/peridot_dagger.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"stab",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/peridot_greatsword.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/peridot_greatsword.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/peridot_halberd.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/peridot_halberd.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/peridot_hand_axe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/peridot_hand_axe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/peridot_longsword.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/peridot_longsword.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/peridot_mace.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/peridot_mace.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/peridot_scimitar.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/peridot_scimitar.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/peridot_sickle.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/peridot_sickle.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/peridot_spear.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/peridot_spear.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"stab",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/peridot_sword.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/peridot_sword.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/peridot_warhammer.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/peridot_warhammer.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/platinum_armor_boots.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/platinum_armor_boots.json
@@ -1,0 +1,14 @@
+{
+	"defense_style":{
+		"slash":10,
+		"stab":10,
+		"magic":10,
+		"projectile":10
+	},
+	
+	"defense_element":{
+		"fire":20,
+		"ice":20,
+		"darkness":-20
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/platinum_armor_chestplate.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/platinum_armor_chestplate.json
@@ -1,0 +1,14 @@
+{
+	"defense_style":{
+		"slash":15,
+		"stab":15,
+		"projectile":10,
+		"explosion":10
+	},
+	
+	"defense_element":{
+		"water":20,
+		"thunder":20,
+		"earth":-20
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/platinum_armor_helmet.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/platinum_armor_helmet.json
@@ -1,0 +1,14 @@
+{
+	"defense_style":{
+		"slash":10,
+		"stab":10,
+		"magic":10,
+		"explosion":10
+	},
+	
+	"defense_element":{
+		"fire":20,
+		"thunder":20,
+		"light":-20
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/platinum_armor_leggings.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/platinum_armor_leggings.json
@@ -1,0 +1,13 @@
+{
+	"defense_style":{
+		"slash":15,
+		"stab":15,
+		"explosion":20
+	},
+	
+	"defense_element":{
+		"water":20,
+		"ice":20,
+		"wind":-20
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/platinum_axe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/platinum_axe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/platinum_battleaxe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/platinum_battleaxe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/platinum_dagger.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/platinum_dagger.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"stab",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/platinum_greatsword.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/platinum_greatsword.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/platinum_halberd.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/platinum_halberd.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/platinum_hand_axe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/platinum_hand_axe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/platinum_longsword.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/platinum_longsword.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/platinum_mace.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/platinum_mace.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/platinum_scimitar.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/platinum_scimitar.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/platinum_sickle.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/platinum_sickle.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/platinum_spear.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/platinum_spear.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"stab",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/platinum_sword.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/platinum_sword.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/platinum_warhammer.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/platinum_warhammer.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/ruby_axe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/ruby_axe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"fire",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/ruby_battleaxe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/ruby_battleaxe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"fire",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/ruby_dagger.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/ruby_dagger.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"stab",
+	"attack_element":"fire",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/ruby_greatsword.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/ruby_greatsword.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"fire",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/ruby_halberd.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/ruby_halberd.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"fire",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/ruby_hand_axe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/ruby_hand_axe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"fire",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/ruby_javelin.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/ruby_javelin.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"stab",
+	"attack_element":"fire",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/ruby_longsword.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/ruby_longsword.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"fire",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/ruby_mace.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/ruby_mace.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"fire",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/ruby_scimitar.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/ruby_scimitar.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"fire",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/ruby_sickle.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/ruby_sickle.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"fire",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/ruby_spear.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/ruby_spear.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"stab",
+	"attack_element":"fire",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/ruby_sword.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/ruby_sword.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"fire",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/ruby_warhammer.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/ruby_warhammer.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"fire",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/rubya_boots.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/rubya_boots.json
@@ -1,0 +1,14 @@
+{
+	"defense_style":{
+		"slash":2,
+		"stab":6,
+		"projectile":2,
+		"explosion":5
+	},
+	
+	"defense_element":{
+		"fire":10,
+		"water":-10,
+		"thunder":10
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/rubya_chestplate.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/rubya_chestplate.json
@@ -1,0 +1,14 @@
+{
+	"defense_style":{
+		"slash":5,
+		"stab":2,
+		"projectile":5,
+		"explosion":5
+	},
+	
+	"defense_element":{
+		"fire":10,
+		"ice":-10,
+		"thunder":10
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/rubya_helmet.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/rubya_helmet.json
@@ -1,0 +1,14 @@
+{
+	"defense_style":{
+		"slash":6,
+		"stab":2,
+		"projectile":2,
+		"explosion":5
+	},
+	
+	"defense_element":{
+		"fire":10,
+		"water":-10,
+		"thunder":10
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/rubya_leggings.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/rubya_leggings.json
@@ -1,0 +1,14 @@
+{
+	"defense_style":{
+		"slash":5,
+		"stab":5,
+		"projectile":2,
+		"explosion":5
+	},
+	
+	"defense_element":{
+		"fire":30,
+		"ice":-10,
+		"water":-10
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/sapphire_armor_boots.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/sapphire_armor_boots.json
@@ -1,0 +1,14 @@
+{
+	"defense_style":{
+		"slash":3,
+		"stab":3,
+		"projectile":2,
+		"magic":5
+	},
+	
+	"defense_element":{
+		"fire":-10,
+		"ice":10,
+		"water":10
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/sapphire_armor_chestplate.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/sapphire_armor_chestplate.json
@@ -1,0 +1,14 @@
+{
+	"defense_style":{
+		"slash":6,
+		"stab":6,
+		"projectile":2,
+		"magic":5
+	},
+	
+	"defense_element":{
+		"fire":-10,
+		"ice":10,
+		"earth":10
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/sapphire_armor_helmet.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/sapphire_armor_helmet.json
@@ -1,0 +1,14 @@
+{
+	"defense_style":{
+		"slash":3,
+		"stab":3,
+		"projectile":2,
+		"magic":5
+	},
+	
+	"defense_element":{
+		"fire":-10,
+		"ice":10,
+		"water":10
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/sapphire_armor_leggings.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/sapphire_armor_leggings.json
@@ -1,0 +1,13 @@
+{
+	"defense_style":{
+		"slash":5,
+		"projectile":8,
+		"magic":3
+	},
+	
+	"defense_element":{
+		"fire":-20,
+		"ice":20,
+		"water":10
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/sapphire_axe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/sapphire_axe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"ice",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/sapphire_battleaxe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/sapphire_battleaxe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"ice",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/sapphire_dagger.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/sapphire_dagger.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"stab",
+	"attack_element":"ice",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/sapphire_greatsword.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/sapphire_greatsword.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"ice",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/sapphire_halberd.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/sapphire_halberd.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"ice",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/sapphire_hand_axe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/sapphire_hand_axe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"ice",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/sapphire_longsword.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/sapphire_longsword.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"ice",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/sapphire_mace.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/sapphire_mace.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"ice",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/sapphire_scimitar.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/sapphire_scimitar.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"ice",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/sapphire_sickle.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/sapphire_sickle.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"ice",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/sapphire_spear.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/sapphire_spear.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"stab",
+	"attack_element":"ice",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/sapphire_sword.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/sapphire_sword.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"ice",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/sapphire_warhammer.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/sapphire_warhammer.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"ice",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/silver_armor_boots.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/silver_armor_boots.json
@@ -1,0 +1,12 @@
+{
+	"defense_style":{
+		"slash":4,
+		"stab":5,
+		"magic":5,
+		"explosion":5
+	},
+	
+	"defense_element":{
+		"light":10
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/silver_armor_chestplate.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/silver_armor_chestplate.json
@@ -1,0 +1,12 @@
+{
+	"defense_style":{
+		"slash":8,
+		"stab":8,
+		"magic":5,
+		"explosion":5
+	},
+	
+	"defense_element":{
+		"light":10
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/silver_armor_helmet.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/silver_armor_helmet.json
@@ -1,0 +1,12 @@
+{
+	"defense_style":{
+		"slash":6,
+		"stab":3,
+		"magic":5,
+		"explosion":5
+	},
+	
+	"defense_element":{
+		"light":10
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/silver_armor_leggings.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/silver_armor_leggings.json
@@ -1,0 +1,12 @@
+{
+	"defense_style":{
+		"slash":7,
+		"stab":7,
+		"magic":5,
+		"explosion":5
+	},
+	
+	"defense_element":{
+		"light":10
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/silver_axe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/silver_axe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"light",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/silver_battleaxe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/silver_battleaxe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"light",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/silver_dagger.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/silver_dagger.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"stab",
+	"attack_element":"light",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/silver_greatsword.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/silver_greatsword.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"light",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/silver_halberd.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/silver_halberd.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"light",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/silver_hand_axe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/silver_hand_axe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"light",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/silver_longsword.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/silver_longsword.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"light",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/silver_mace.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/silver_mace.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"light",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/silver_scimitar.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/silver_scimitar.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"light",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/silver_sickle.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/silver_sickle.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"light",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/silver_spear.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/silver_spear.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"stab",
+	"attack_element":"light",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/silver_sword.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/silver_sword.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"light",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/silver_warhammer.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/silver_warhammer.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"light",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/staff.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/staff.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/stone_axe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/stone_axe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/stone_battleaxe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/stone_battleaxe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/stone_greatsword.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/stone_greatsword.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/stone_hand_axe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/stone_hand_axe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/stone_longsword.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/stone_longsword.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/stone_mace.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/stone_mace.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/stone_scimitar.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/stone_scimitar.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/stone_sickle.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/stone_sickle.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/stone_spear.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/stone_spear.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"stab",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/stone_sword.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/stone_sword.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/stone_warhammer.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/stone_warhammer.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"explosion",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/swordof_life_stealing.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/swordof_life_stealing.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"bio",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/tin_armor_boots.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/tin_armor_boots.json
@@ -1,0 +1,12 @@
+{
+	"defense_style":{
+		"slash":6,
+		"stab":5,
+		"magic":2,
+		"explosion":8,
+		"projectile":3
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/tin_armor_chestplate.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/tin_armor_chestplate.json
@@ -1,0 +1,11 @@
+{
+	"defense_style":{
+		"slash":6,
+		"stab":6,
+		"explosion":7,
+		"projectile":7
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/tin_armor_helmet.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/tin_armor_helmet.json
@@ -1,0 +1,12 @@
+{
+	"defense_style":{
+		"slash":3,
+		"stab":6,
+		"magic":5,
+		"explosion":5,
+		"projectile":7
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/tin_armor_leggings.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/tin_armor_leggings.json
@@ -1,0 +1,11 @@
+{
+	"defense_style":{
+		"slash":8,
+		"stab":8,
+		"explosion":2,
+		"projectile":7
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/tin_axe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/tin_axe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/tin_battleaxe.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/tin_battleaxe.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/tin_dagger.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/tin_dagger.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"stab",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/tin_greatsword.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/tin_greatsword.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/data/elementalcombat/combat_properties/items/tin_halberd.json
+++ b/dndmc datapack/data/elementalcombat/combat_properties/items/tin_halberd.json
@@ -1,0 +1,10 @@
+{
+	"attack_style":"slash",
+	"attack_element":"natural",
+	
+	"defense_style":{
+	},
+	
+	"defense_element":{
+	}
+}

--- a/dndmc datapack/pack.mcmeta
+++ b/dndmc datapack/pack.mcmeta
@@ -1,0 +1,6 @@
+{
+  "pack": {
+    "pack_format": 6,
+    "description": "dndmc datapack"
+  }
+}


### PR DESCRIPTION
So this should work :)

Essentially I took the base stats from dnd 5e and adnd, or in rare cases their lore if stats didn't exist, and translated it wind/earth/explosion/etc. The main thing I did was started using explosion for blunt attacks like hammers or clubs. It seemed kind of appropriate since the armors have lots of varying explosion resistances, so you can build against it which should balance it? Not sure if other algorithms exist for their damage calculation I don't know about...

Anyways, I've also been testing it out just by playing through the game in the rpg modpack I'm building. I think another great way I'll try testing (mostly because the dimensions are a bit further into the game) is just grabbing spawn eggs and using various weapons with the different damage type enchants as slash.

Magic seems tricky, it seems to work for the spells/staves I have tried so far though. A lot of the spells (if not all?) use entities for the projectiles....which makes it easy to just slap a json file for it in entities. I also created one for each of those spell/weapons in the items folder with the same info just in case that doesn't work. I will be doing a lot of further testing with spells as I'm working on getting them registered as magic weapons in pmmo as well, which is proving to be tricky...lol